### PR TITLE
feat: add Docker router-based testbed

### DIFF
--- a/testbed/README.md
+++ b/testbed/README.md
@@ -1,56 +1,151 @@
-# discv5 testbed
+# discv5 DISC-NG testbed
 
-### Installing Dependencies
+Testbed for running DISC-NG topic discovery experiments.
 
-You need Python >= 3.9.
+## Modes
 
-It is recommended to use virtualenv to keep your Python package collection in check.
-Create your environment like this:
+### Local (default)
 
-```
-python3 -m venv .virtualenv
-```
+All nodes run as local processes on `127.0.0.1`. Fast, no Docker needed.
+IP diversity scoring is not exercised (all nodes share localhost).
 
-Now enter the environment (assuming a bash-like shell). This sets up your PATH and
-Python-related environment variables to store everything in `.virtualenv`.
-
-```
-source .virtalenv/bin/activate
+```bash
+testbed/run.py --config testbed/discv5-smallconfig.json --name my-test
 ```
 
-Now install the dependencies:
+### Docker (with router-based NAT simulation)
 
-```
-python -m pip install -r requirements.txt
-```
+Nodes run in Docker containers with a single router container that:
+- Assigns virtual public IPs from scattered ranges (different /8, /16, /24)
+- Simulates NAT behavior per node (public, NATted, port-forwarded)
+- Applies per-node network latency via `tc netem`
 
-### Running Experiments
+Requires Linux with Docker (not macOS Docker Desktop).
 
-All commands are to be executed from the go-ethereum project root directory. If you are
-using virtualenv, remember to enter the environment first.
-
-You can run the testbed with default settings like this:
-
-```
-testbed/run.py
+```bash
+testbed/run.py --docker --config testbed/discv5-docker-config.json --name my-test
 ```
 
-There are several customization options available. You can run a single experiment with
-custom configuration using the command below. Check out discv5-stdconfig.json for an
-overview of the available parameters.
+## Installing Dependencies
+
+Python >= 3.9 required.
+
+```bash
+python3 -m venv testbed/.venv
+source testbed/.venv/bin/activate
+pip install -r testbed/requirements.txt
+```
+
+## Configuration
+
+All commands run from the go-ethereum project root directory.
+
+### Common parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nodes` | Total number of nodes | 500 |
+| `topic` | Number of distinct topics | 1 |
+| `searchIterations` | Searches per node | 5 |
+| `returnedNodes` | Max results per search | 30 |
+
+### Node parameters (passed to devp2p)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `pingInterval` | Liveness check interval (seconds) | 10 |
+| `bucketRefreshInterval` | Kademlia bucket refresh (seconds) | 60 |
+| `adCacheSize` | Topic table capacity | 500 |
+| `adLifetimeSeconds` | Ad expiry time (seconds) | 60 |
+| `regBucketSize` | Active registrations per bucket | 10 |
+| `regBucketStandbySize` | Standby registrations per bucket | 10 |
+| `searchBucketSize` | Nodes per search bucket | 5 |
+| `rpcSearchTimeoutSeconds` | RPC search timeout (seconds) | 120 |
+
+### Docker NAT parameters (only with `--docker`)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nattedNodes` | Nodes behind NAT (unreachable) | 0 |
+| `portForwardedNodes` | NATted nodes with port forwarding (reachable on discv5 port) | 0 |
+| `minLatencyMs` | Minimum per-node latency (ms) | 2 |
+| `maxLatencyMs` | Maximum per-node latency (ms) | 40 |
+| `publicIpFile` | File with custom public IPs (one per line, optional) | generated |
+| `latencyFile` | File with per-node latencies in ms (one per line, optional) | random uniform |
+
+Node assignment order: public nodes first, then port-forwarded, then NATted.
+Remaining `nodes - nattedNodes - portForwardedNodes` are public.
+
+### Example configs
+
+```bash
+# 5 nodes, local, quick test
+testbed/run.py --config testbed/discv5-smallconfig.json --name quick-test
+
+# 100 nodes, Docker, mixed NAT (50 public + 20 port-forwarded + 30 NATted)
+testbed/run.py --docker --config testbed/discv5-docker-config.json --name nat-test
+
+# 500 nodes, local, standard benchmark
+testbed/run.py --config testbed/discv5-stdconfig.json --name benchmark
+```
+
+## Running experiments
+
+```bash
+# Run with analysis (default)
+testbed/run.py --config <config.json> --name <experiment-name>
+
+# Run without analysis
+testbed/run.py --config <config.json> --name <experiment-name> --no-analysis
+
+# Re-run analysis on existing logs
+testbed/analyse.py ./discv5_test_logs/<experiment-name>
+```
+
+## Results
+
+Results are written to `discv5_test_logs/<name>/`:
 
 ```
-testbed/run.py --config myconfig.json
+discv5_test_logs/<name>/
+  config.json          Node-level config
+  experiment.json      Full experiment parameters
+  node_mappings.txt    IP mappings and NAT types (Docker mode)
+  keys/                Node keys and ID index
+  logs/
+    node-*.log         Per-node JSON logs
+    logs.json          Workload events (registrations + searches)
+  dfs/                 Parsed dataframes (JSON)
+  figs/                Analysis plots (PDF)
 ```
 
-By default, `run.py` will perform analysis after running the experiment. This can be
-disabled using the `--no-analysis` flag.
+### Generated plots
 
-Logs and analysis outputs will be written to a subdirectoy of `discv5_test_logs/` named
-after the experiment parameters. You can override the name using the `--name` flag.
+| Plot | Description |
+|------|-------------|
+| `discovered_search.pdf` | Avg lookup results per node |
+| `times_registered.pdf` | Successful registrations per node |
+| `times_registered_dist.pdf` | Registration distribution across DHT |
+| `operation_time.pdf` | Search times by topic |
+| `waiting_time.pdf` | Admission control waiting times by topic |
+| `msg_type_count.pdf` | Protocol message type counts |
+| `times_discovered.pdf` | How often each node appears in results |
+| `op_returned.pdf` | Results returned per operation |
 
-If you want to re-run analysis for a past experiment, use the following command:
+## Docker architecture
 
 ```
-testbed/analyse.py ./discv5_test_logs/<experiment>
+Single Docker bridge: 10.100.0.0/16
+
+Router (10.100.0.1)
+  - Assigns virtual public IPs from scattered /8 ranges
+  - Per-node iptables rules:
+    * public:         SNAT + full DNAT (all inbound accepted)
+    * port-forwarded: SNAT + DNAT on UDP 30303 only
+    * natted:         SNAT only (no inbound except responses)
+
+Nodes (10.100.0.x)
+  - Default gateway set to router
+  - All traffic goes through router's NAT rules
+  - ENRs advertise virtual public IPs
 ```

--- a/testbed/discv5-docker-config.json
+++ b/testbed/discv5-docker-config.json
@@ -1,0 +1,22 @@
+{
+    "nodes": 100,
+    "topic": 5,
+    "searchIterations": 3,
+    "returnedNodes": 20,
+
+    "pingInterval": 10,
+    "bucketRefreshInterval": 60,
+    "adCacheSize": 500,
+    "adLifetimeSeconds": 60,
+    "regBucketSize": 10,
+    "regBucketStandbySize": 10,
+    "searchBucketSize": 5,
+
+    "rpcSearchTimeoutSeconds": 120,
+
+    "nattedNodes": 30,
+    "portForwardedNodes": 20,
+
+    "minLatencyMs": 2,
+    "maxLatencyMs": 40
+}

--- a/testbed/docker/node/Dockerfile
+++ b/testbed/docker/node/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev linux-headers git
+
+COPY go.mod go.sum /go-ethereum/
+RUN cd /go-ethereum && go mod download
+
+COPY . /go-ethereum/
+RUN cd /go-ethereum && go build -o /devp2p ./cmd/devp2p
+
+FROM alpine:3.20
+
+RUN apk add --no-cache iproute2 bash iptables
+COPY --from=builder /devp2p /usr/local/bin/devp2p
+COPY testbed/docker/node/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/testbed/docker/node/entrypoint.sh
+++ b/testbed/docker/node/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set default gateway to router if GATEWAY is set.
+if [ -n "$GATEWAY" ]; then
+    echo "Setting default gateway to $GATEWAY"
+    ip route del default 2>/dev/null || true
+    ip route add default via "$GATEWAY"
+fi
+
+exec "$@"

--- a/testbed/docker/router/Dockerfile
+++ b/testbed/docker/router/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache iptables iproute2 bash
+COPY testbed/docker/router/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/testbed/docker/router/entrypoint.sh
+++ b/testbed/docker/router/entrypoint.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+# NODE_MAPPINGS is a file with one line per node:
+#   <private_ip> <public_ip> <type>
+# where type is: public, natted, port-forwarded
+#
+# Example:
+#   10.100.0.11 45.1.1.1 public
+#   10.100.0.12 51.1.2.1 natted
+#   10.100.0.13 64.1.3.1 port-forwarded
+
+MAPPINGS_FILE="${MAPPINGS_FILE:-/config/node_mappings.txt}"
+DISCV5_PORT="${DISCV5_PORT:-30303}"
+
+if [ ! -f "$MAPPINGS_FILE" ]; then
+    echo "ERROR: Mappings file not found: $MAPPINGS_FILE"
+    exit 1
+fi
+
+# Enable IP forwarding.
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+# Create dummy interface for virtual public IPs.
+ip link add dummy0 type dummy
+ip link set dummy0 up
+
+# Flush existing rules.
+iptables -F FORWARD
+iptables -t nat -F
+
+# Default: allow outbound from all nodes, drop unsolicited inbound.
+# Per-node rules below override as needed.
+
+echo "Loading node mappings from $MAPPINGS_FILE"
+
+while read -r PRIV_IP PUB_IP TYPE; do
+    # Skip empty lines and comments.
+    [ -z "$PRIV_IP" ] && continue
+    [[ "$PRIV_IP" == \#* ]] && continue
+
+    echo "  $PRIV_IP -> $PUB_IP ($TYPE)"
+
+    # Add virtual public IP to dummy interface.
+    ip addr add "$PUB_IP/32" dev dummy0 2>/dev/null || true
+
+    # SNAT: outbound from private IP appears as public IP.
+    iptables -t nat -A POSTROUTING -s "$PRIV_IP" -j SNAT --to-source "$PUB_IP"
+
+    case "$TYPE" in
+        public)
+            # Full DNAT + unrestricted forwarding.
+            iptables -t nat -A PREROUTING -d "$PUB_IP" -j DNAT --to-destination "$PRIV_IP"
+            iptables -A FORWARD -d "$PRIV_IP" -j ACCEPT
+            ;;
+        port-forwarded)
+            # DNAT only on the discv5 UDP port.
+            iptables -t nat -A PREROUTING -d "$PUB_IP" -p udp --dport "$DISCV5_PORT" \
+                -j DNAT --to-destination "$PRIV_IP:$DISCV5_PORT"
+            iptables -A FORWARD -d "$PRIV_IP" -p udp --dport "$DISCV5_PORT" -j ACCEPT
+            # Everything else: only established/related (responses to outbound).
+            iptables -A FORWARD -d "$PRIV_IP" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+            ;;
+        natted)
+            # No DNAT. Only responses to the node's own outbound get through.
+            iptables -A FORWARD -d "$PRIV_IP" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+            ;;
+        *)
+            echo "  WARNING: unknown type '$TYPE', treating as natted"
+            iptables -A FORWARD -d "$PRIV_IP" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+            ;;
+    esac
+
+    # Always allow outbound from this node.
+    iptables -A FORWARD -s "$PRIV_IP" -j ACCEPT
+
+done < "$MAPPINGS_FILE"
+
+# Drop everything else.
+iptables -A FORWARD -j DROP
+
+echo ""
+echo "Router ready. $(wc -l < "$MAPPINGS_FILE") node mappings loaded."
+echo "iptables rules:"
+iptables -L FORWARD -n --line-numbers
+echo ""
+iptables -t nat -L -n --line-numbers
+
+# Keep running.
+exec sleep infinity

--- a/testbed/docker/router/entrypoint.sh
+++ b/testbed/docker/router/entrypoint.sh
@@ -18,12 +18,17 @@ if [ ! -f "$MAPPINGS_FILE" ]; then
     exit 1
 fi
 
-# Enable IP forwarding.
-echo 1 > /proc/sys/net/ipv4/ip_forward
+# Note: IP forwarding is enabled via --sysctl net.ipv4.ip_forward=1 in docker run.
 
-# Create dummy interface for virtual public IPs.
-ip link add dummy0 type dummy
-ip link set dummy0 up
+# Create a loopback alias for virtual public IPs (dummy module may not be available).
+# We use 'lo' as a fallback.
+if ip link add dummy0 type dummy 2>/dev/null; then
+    ip link set dummy0 up
+    PUB_DEV=dummy0
+else
+    echo "WARNING: dummy interface not available, using lo for virtual IPs"
+    PUB_DEV=lo
+fi
 
 # Flush existing rules.
 iptables -F FORWARD
@@ -41,8 +46,8 @@ while read -r PRIV_IP PUB_IP TYPE; do
 
     echo "  $PRIV_IP -> $PUB_IP ($TYPE)"
 
-    # Add virtual public IP to dummy interface.
-    ip addr add "$PUB_IP/32" dev dummy0 2>/dev/null || true
+    # Add virtual public IP.
+    ip addr add "$PUB_IP/32" dev $PUB_DEV 2>/dev/null || true
 
     # SNAT: outbound from private IP appears as public IP.
     iptables -t nat -A POSTROUTING -s "$PRIV_IP" -j SNAT --to-source "$PUB_IP"

--- a/testbed/run.py
+++ b/testbed/run.py
@@ -12,7 +12,7 @@ from testbed import workload, analysis
 
 def parseArguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--docker", help="enable docker testbed", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--docker", help="enable docker testbed with router-based NAT simulation", action=argparse.BooleanOptionalAction)
     parser.add_argument("--analysis", help="run analysis after test", default=True, action=argparse.BooleanOptionalAction)
     parser.add_argument("--config", help="run chosen configuration", type=str)
     parser.add_argument("--name", help="experiment name", type=str)
@@ -72,7 +72,7 @@ def main():
 
     network = NetworkLocal()
     if args.docker:
-        network = NetworkDocker()
+        network = NetworkDockerRouter()
     atexit.register(network.stop)
 
     params = {}

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -29,6 +29,21 @@ network_config_defaults = {
 MIN_LATENCY=2
 MAX_LATENCY=40
 
+# Safe first octets for virtual public IPs (non-private, non-reserved).
+SAFE_OCTETS = [45, 51, 64, 78, 85, 91, 104, 138, 155, 163, 185, 193, 203, 212]
+
+def public_ip_for_node(node: int) -> str:
+    """Generate a virtual public IP scattered across different /8, /16, /24 ranges."""
+    i = node - 1  # node is 1-based
+    first = SAFE_OCTETS[i % len(SAFE_OCTETS)]
+    second = (i // len(SAFE_OCTETS)) + 1
+    third = (i % 250) + 1
+    return f"{first}.{second}.{third}.1"
+
+def private_ip_for_node(node: int) -> str:
+    """Private IP on the Docker bridge network."""
+    return f"10.100.{node // 256}.{node % 256}"
+
 class Network:
     config: dict = {}
 
@@ -232,12 +247,176 @@ class NetworkDocker(Network):
         latency = random.randint(MIN_LATENCY,MAX_LATENCY)
         subprocess.Popen("docker exec node"+str(node)+" sh -c 'tc qdisc add dev eth0 root netem delay "+str(latency)+"ms'", stdout=subprocess.DEVNULL, stderr=None,shell=True)
 
-        #command = 'sh -c "tc qdisc add dev eth0 root netem delay '+str(latency)+'ms"'
-        #argv = ["docker","exec","node"+str(node),command]
-        #p = subprocess.run(argv, capture_output=True, text=True)
-        #if p.returncode != 0:
-        #    print(p.stderr)
-        #    p.check_returncode()
+
+class NetworkDockerRouter(Network):
+    """Docker-based network with a single router container that simulates
+    diverse public IPs and NAT behaviors using iptables.
+
+    All nodes are on a single Docker bridge (10.100.0.0/16). The router
+    assigns virtual public IPs from scattered ranges and applies per-node
+    NAT rules (public, natted, port-forwarded).
+    """
+
+    DOCKER_NETWORK = 'discv5-testnet'
+    DOCKER_SUBNET = '10.100.0.0/16'
+    ROUTER_IP = '10.100.0.1'
+    DISCV5_PORT = 30303
+    RPC_PORT = 20200
+    PROJECT = 'discv5'
+
+    containers: list[str] = []
+    node_types: dict[int, str] = {}  # node -> 'public'|'natted'|'port-forwarded'
+
+    def __init__(self, config=None):
+        cfg = {
+            'rpcBasePort': self.RPC_PORT,
+            'udpBasePort': self.DISCV5_PORT,
+        }
+        if config:
+            cfg.update(config)
+        super().__init__(cfg)
+
+    def build(self):
+        print('Building Docker images...')
+        result = os.system(
+            "docker build -t discv5-node -f testbed/docker/node/Dockerfile ."
+        )
+        assert result == 0, "Failed to build node image"
+        result = os.system(
+            "docker build -t discv5-router -f testbed/docker/router/Dockerfile ."
+        )
+        assert result == 0, "Failed to build router image"
+
+    def classify_nodes(self, params: dict):
+        """Assign node types based on config parameters."""
+        n = params['nodes']
+        natted = params.get('nattedNodes', 0)
+        forwarded = params.get('portForwardedNodes', 0)
+        public = n - natted - forwarded
+
+        assert public >= 0, "nattedNodes + portForwardedNodes > nodes"
+
+        self.node_types = {}
+        node = 1
+        for _ in range(public):
+            self.node_types[node] = 'public'
+            node += 1
+        for _ in range(forwarded):
+            self.node_types[node] = 'port-forwarded'
+            node += 1
+        for _ in range(natted):
+            self.node_types[node] = 'natted'
+            node += 1
+
+    def node_udp_endpoint(self, node: int):
+        """Returns the virtual public IP and port for a node."""
+        return (public_ip_for_node(node), self.DISCV5_PORT)
+
+    def node_api_url(self, node: int):
+        """Returns the RPC URL using the private (Docker bridge) IP."""
+        priv_ip = private_ip_for_node(node)
+        return f"http://{priv_ip}:{self.RPC_PORT}"
+
+    def _create_network(self):
+        """Create the Docker bridge network."""
+        # Remove existing network if present.
+        os.system(f"docker network rm {self.DOCKER_NETWORK} 2>/dev/null")
+        argv = [
+            'docker', 'network', 'create',
+            '--subnet', self.DOCKER_SUBNET,
+            '--gateway', self.ROUTER_IP,
+            self.DOCKER_NETWORK,
+        ]
+        p = subprocess.run(argv, capture_output=True, text=True)
+        if p.returncode != 0:
+            print('docker network create failed:', p.stderr)
+            p.check_returncode()
+
+    def _write_mappings(self, config_path: str, n: int):
+        """Write the node_mappings.txt file for the router."""
+        mappings_file = os.path.join(config_path, "node_mappings.txt")
+        with open(mappings_file, 'w') as f:
+            f.write("# private_ip public_ip type\n")
+            for node in range(1, n + 1):
+                priv_ip = private_ip_for_node(node)
+                pub_ip = public_ip_for_node(node)
+                ntype = self.node_types.get(node, 'public')
+                f.write(f"{priv_ip} {pub_ip} {ntype}\n")
+        return mappings_file
+
+    def _start_router(self, config_path: str):
+        """Start the router container."""
+        abs_config_path = os.path.abspath(config_path)
+        argv = [
+            'docker', 'run', '-d',
+            '--name', f'{self.PROJECT}-router',
+            '--network', self.DOCKER_NETWORK,
+            '--ip', self.ROUTER_IP,
+            '--cap-add', 'NET_ADMIN',
+            '--mount', f'type=bind,source={abs_config_path},target=/config',
+            'discv5-router',
+        ]
+        p = subprocess.run(argv, capture_output=True, text=True)
+        if p.returncode != 0:
+            print('Router start failed:', p.stderr)
+            p.check_returncode()
+
+        container_id = p.stdout.strip()
+        print(f'Started router: {container_id[:12]}')
+        self.containers.append(container_id)
+
+        # Wait for router to be ready.
+        import time
+        time.sleep(2)
+
+    def start_node(self, node: int, bootnodes=[], nodekey=None, config_path=None):
+        assert nodekey is not None
+        assert config_path is not None
+
+        abs_config_path = os.path.abspath(config_path)
+        priv_ip = private_ip_for_node(node)
+        pub_ip = public_ip_for_node(node)
+
+        nodeflags = [
+            "--bootnodes", ','.join(bootnodes),
+            "--nodekey", nodekey,
+            "--addr", f"{priv_ip}:{self.DISCV5_PORT}",
+            "--rpc", f"{priv_ip}:{self.RPC_PORT}",
+            "--config", "/config/config.json",
+        ]
+        logfile = f"/config/logs/node-{node}.log"
+        logflags = ["--verbosity", "5", "--log.json", "--log.file", logfile]
+
+        argv = [
+            'docker', 'run', '-d',
+            '--name', f'{self.PROJECT}-node-{node}',
+            '--network', self.DOCKER_NETWORK,
+            '--ip', priv_ip,
+            '--cap-add', 'NET_ADMIN',
+            '-e', f'GATEWAY={self.ROUTER_IP}',
+            '--mount', f'type=bind,source={abs_config_path},target=/config',
+            'discv5-node',
+            'devp2p', *logflags, 'discv5', 'listen', *nodeflags,
+        ]
+        p = subprocess.run(argv, capture_output=True, text=True)
+        if p.returncode != 0:
+            print(f'Node {node} start failed:', p.stderr)
+            p.check_returncode()
+
+        container_id = p.stdout.strip()
+        ntype = self.node_types.get(node, 'public')
+        print(f'Started node {node} ({ntype}): {priv_ip} -> {pub_ip}')
+        self.containers.append(container_id)
+
+    def stop(self):
+        super().stop()
+        if self.containers:
+            print('Stopping containers...')
+        for cid in self.containers:
+            os.system(f'docker rm -f {cid} 2>/dev/null')
+        self.containers = []
+        os.system(f'docker network rm {self.DOCKER_NETWORK} 2>/dev/null')
+
 
 # _async_iter_concurrently runs fn over items. The function must return a
 # coroutine, which will be scheduled as a task.
@@ -343,8 +522,60 @@ def make_keys(config_path: str, n: int):
 def select_bootnodes(enrs):
     return [ enrs[0] ] + random.sample(enrs[1:], min(len(enrs)//3, 20))
 
+def load_ip_list(filepath: str) -> list[str]:
+    """Load public IPs from a file (one IP per line)."""
+    ips = []
+    with open(filepath) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                ips.append(line)
+    return ips
+
+
+def load_latency_list(filepath: str) -> list[int]:
+    """Load per-node latencies from a file (one value in ms per line)."""
+    latencies = []
+    with open(filepath) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                latencies.append(int(line))
+    return latencies
+
+
+def generate_latencies(n: int, params: dict) -> list[int]:
+    """Generate latencies per node from config (random uniform or from file)."""
+    latency_file = params.get('latencyFile')
+    if latency_file and os.path.isfile(latency_file):
+        latencies = load_latency_list(latency_file)
+        if len(latencies) < n:
+            # Cycle if file has fewer entries than nodes.
+            latencies = (latencies * ((n // len(latencies)) + 1))[:n]
+        return latencies[:n]
+
+    min_lat = params.get('minLatencyMs', MIN_LATENCY)
+    max_lat = params.get('maxLatencyMs', MAX_LATENCY)
+    return [random.randint(min_lat, max_lat) for _ in range(n)]
+
+
 def start_nodes(network: Network, config_path: str, params: dict):
     n = params['nodes']
+
+    # For NetworkDockerRouter, classify nodes and set up IP mappings.
+    if isinstance(network, NetworkDockerRouter):
+        network.classify_nodes(params)
+
+        # Load or generate public IPs.
+        ip_file = params.get('publicIpFile')
+        if ip_file and os.path.isfile(ip_file):
+            custom_ips = load_ip_list(ip_file)
+            if len(custom_ips) < n:
+                raise ValueError(f"IP file has {len(custom_ips)} IPs but need {n}")
+            # Override the IP function with custom IPs.
+            ip_map = {i+1: custom_ips[i] for i in range(n)}
+            original_endpoint = network.node_udp_endpoint
+            network.node_udp_endpoint = lambda node: (ip_map[node], network.DISCV5_PORT)
 
     print("Building keys...")
     make_keys(config_path, params['nodes'])
@@ -357,7 +588,11 @@ def start_nodes(network: Network, config_path: str, params: dict):
 
     print("Starting", n, "nodes...")
 
-    if isinstance(network, NetworkDocker):
+    if isinstance(network, NetworkDockerRouter):
+        network._create_network()
+        network._write_mappings(config_path, n)
+        network._start_router(config_path)
+    elif isinstance(network, NetworkDocker):
         network.create_docker_networks(n)
         os.system("sudo iptables --flush DOCKER-ISOLATION-STAGE-1")
 
@@ -370,6 +605,19 @@ def start_nodes(network: Network, config_path: str, params: dict):
 
         if isinstance(network, NetworkDocker):
             network.config_network(i)
+
+    # Apply latencies.
+    if isinstance(network, NetworkDockerRouter):
+        latencies = generate_latencies(n, params)
+        for i in range(1, n+1):
+            lat = latencies[i-1]
+            if lat > 0:
+                container = f'{network.PROJECT}-node-{i}'
+                os.system(
+                    f"docker exec {container} sh -c "
+                    f"'tc qdisc add dev eth0 root netem delay {lat}ms' 2>/dev/null"
+                )
+        print(f"Applied latencies: min={min(latencies)}ms max={max(latencies)}ms")
 
     print("Nodes started")
 

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -321,9 +321,9 @@ class NetworkDockerRouter(Network):
         return (public_ip_for_node(node), self.DISCV5_PORT)
 
     def node_api_url(self, node: int):
-        """Returns the RPC URL using the private (Docker bridge) IP."""
-        priv_ip = private_ip_for_node(node)
-        return f"http://{priv_ip}:{self.RPC_PORT}"
+        """Returns the RPC URL via host port mapping."""
+        host_port = self.RPC_PORT + node
+        return f"http://127.0.0.1:{host_port}"
 
     def _create_network(self):
         """Create the Docker bridge network."""
@@ -386,11 +386,13 @@ class NetworkDockerRouter(Network):
         priv_ip = private_ip_for_node(node)
         pub_ip = public_ip_for_node(node)
 
+        host_rpc_port = self.RPC_PORT + node
+
         nodeflags = [
             "--bootnodes", ','.join(bootnodes),
             "--nodekey", nodekey,
             "--addr", f"{priv_ip}:{self.DISCV5_PORT}",
-            "--rpc", f"{priv_ip}:{self.RPC_PORT}",
+            "--rpc", f"0.0.0.0:{self.RPC_PORT}",
             "--config", "/config/config.json",
         ]
         logfile = f"/config/logs/node-{node}.log"
@@ -403,6 +405,7 @@ class NetworkDockerRouter(Network):
             '--ip', priv_ip,
             '--cap-add', 'NET_ADMIN',
             '-e', f'GATEWAY={self.ROUTER_IP}',
+            '-p', f'127.0.0.1:{host_rpc_port}:{self.RPC_PORT}/tcp',
             '--mount', f'type=bind,source={abs_config_path},target=/config',
             'discv5-node',
             'devp2p', *logflags, 'discv5', 'listen', *nodeflags,

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -277,6 +277,11 @@ class NetworkDockerRouter(Network):
         super().__init__(cfg)
 
     def build(self):
+        # Build the local devp2p binary (needed for key generation and ENR creation).
+        print('Compiling devp2p tool')
+        result = os.system("PATH=$PATH:/usr/local/go/bin go build ./cmd/devp2p")
+        assert result == 0, "Failed to build devp2p"
+
         print('Building Docker images...')
         result = os.system(
             "docker build -t discv5-node -f testbed/docker/node/Dockerfile ."

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -361,7 +361,8 @@ class NetworkDockerRouter(Network):
             '--name', f'{self.PROJECT}-router',
             '--network', self.DOCKER_NETWORK,
             '--ip', self.ROUTER_IP,
-            '--cap-add', 'NET_ADMIN',
+            '--privileged',
+            '--sysctl', 'net.ipv4.ip_forward=1',
             '--mount', f'type=bind,source={abs_config_path},target=/config',
             'discv5-router',
         ]

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -327,7 +327,8 @@ class NetworkDockerRouter(Network):
 
     def _create_network(self):
         """Create the Docker bridge network."""
-        # Remove existing network if present.
+        # Force-remove any leftover containers and network from previous runs.
+        os.system(f"docker ps -a --filter network={self.DOCKER_NETWORK} -q | xargs -r docker rm -f 2>/dev/null")
         os.system(f"docker network rm {self.DOCKER_NETWORK} 2>/dev/null")
         argv = [
             'docker', 'network', 'create',

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -41,8 +41,10 @@ def public_ip_for_node(node: int) -> str:
     return f"{first}.{second}.{third}.1"
 
 def private_ip_for_node(node: int) -> str:
-    """Private IP on the Docker bridge network."""
-    return f"10.100.{node // 256}.{node % 256}"
+    """Private IP on the Docker bridge network. Offset by 10 to avoid
+    gateway (.1) and router (.2) addresses."""
+    n = node + 9  # node 1 -> .10, node 2 -> .11, etc.
+    return f"10.100.{n // 256}.{n % 256}"
 
 class Network:
     config: dict = {}
@@ -259,7 +261,8 @@ class NetworkDockerRouter(Network):
 
     DOCKER_NETWORK = 'discv5-testnet'
     DOCKER_SUBNET = '10.100.0.0/16'
-    ROUTER_IP = '10.100.0.1'
+    DOCKER_GATEWAY = '10.100.0.1'
+    ROUTER_IP = '10.100.0.2'
     DISCV5_PORT = 30303
     RPC_PORT = 20200
     PROJECT = 'discv5'
@@ -329,7 +332,7 @@ class NetworkDockerRouter(Network):
         argv = [
             'docker', 'network', 'create',
             '--subnet', self.DOCKER_SUBNET,
-            '--gateway', self.ROUTER_IP,
+            '--gateway', self.DOCKER_GATEWAY,
             self.DOCKER_NETWORK,
         ]
         p = subprocess.run(argv, capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- Docker testbed mode (`--docker`) with a single router container simulating diverse public IPs and NAT behaviors via iptables
- Three node types: public, NATted (unreachable), port-forwarded (reachable on discv5 port)
- Virtual public IPs scattered across different /8, /16, /24 ranges so IP diversity scoring works correctly
- Per-node latency via tc netem, configurable from file or random uniform
- Replaces old NetworkDocker (per-node bridge with private 172.20.x.x IPs that bypassed IP limits)

## New files
- `testbed/docker/node/Dockerfile` + `entrypoint.sh` — geth devp2p node container
- `testbed/docker/router/Dockerfile` + `entrypoint.sh` — iptables NAT rules engine
- `testbed/discv5-docker-config.json` — example config with NAT params
- Updated `testbed/testbed/network.py` with `NetworkDockerRouter` class
- Updated `testbed/README.md` with full documentation

## Test plan
- [ ] Test on Linux machine (ssh sergi@london)
- [ ] Verify router iptables rules are applied correctly
- [ ] Run 100-node experiment with mixed NAT (50 public + 20 port-forwarded + 30 NATted)
- [ ] Verify IP diversity scoring works (non-private IPs)
- [ ] Verify NATted nodes can register but not serve as registrars
- [ ] Verify port-forwarded nodes are reachable on discv5 port
- [ ] Compare results with local mode baseline

Closes #17