### PR TITLE
p2p/discover: add discng ENR capability flag

### DIFF
--- a/p2p/discover/topicindex/common.go
+++ b/p2p/discover/topicindex/common.go
@@ -95,13 +95,27 @@ func (t TopicID) String() string {
 // It indicates that the event should not be scheduled.
 const Never = ^mclock.AbsTime(0)
 
-// DiscNG is an ENR entry indicating that a node supports the DISC-NG
-// topic discovery protocol. Its presence in a node's ENR signals capability.
-type DiscNG struct{}
+// TopicDiscovery is the "topic-discovery" ENR entry. It signals that a node
+// implements the topic discovery capability for Discv5 and is willing to
+// participate in topic service tables, registrations, and lookups. The value
+// is an unsigned integer identifying the supported protocol version, so
+// non-backwards-compatible revisions can bump the value in place rather than
+// introducing a new ENR key.
+type TopicDiscovery uint
 
-func (DiscNG) ENRKey() string { return "discng" }
+// TopicDiscoveryVersion is the protocol version implemented by this code.
+const TopicDiscoveryVersion TopicDiscovery = 1
 
-// SupportsDiscNG reports whether a node's ENR contains the discng capability flag.
-func SupportsDiscNG(n *enode.Node) bool {
-	return n.Record().Load(new(DiscNG)) == nil
+func (TopicDiscovery) ENRKey() string { return "topic-discovery" }
+
+// SupportsTopicDiscovery reports whether n advertises a version of the topic
+// discovery capability that this implementation supports. A node whose ENR
+// does not contain the entry, or whose value does not match a supported
+// version, is treated as not supporting the capability.
+func SupportsTopicDiscovery(n *enode.Node) bool {
+	var v TopicDiscovery
+	if err := n.Record().Load(&v); err != nil {
+		return false
+	}
+	return v == TopicDiscoveryVersion
 }

--- a/p2p/discover/topicindex/common.go
+++ b/p2p/discover/topicindex/common.go
@@ -106,7 +106,7 @@ type TopicDiscovery uint
 // TopicDiscoveryVersion is the protocol version implemented by this code.
 const TopicDiscoveryVersion TopicDiscovery = 1
 
-func (TopicDiscovery) ENRKey() string { return "topic-discovery" }
+func (TopicDiscovery) ENRKey() string { return "ng" }
 
 // SupportsTopicDiscovery reports whether n advertises a version of the topic
 // discovery capability that this implementation supports. A node whose ENR

--- a/p2p/discover/topicindex/common.go
+++ b/p2p/discover/topicindex/common.go
@@ -94,3 +94,14 @@ func (t TopicID) String() string {
 // Never is a special time value returned by certain event-scheduling functions.
 // It indicates that the event should not be scheduled.
 const Never = ^mclock.AbsTime(0)
+
+// DiscNG is an ENR entry indicating that a node supports the DISC-NG
+// topic discovery protocol. Its presence in a node's ENR signals capability.
+type DiscNG struct{}
+
+func (DiscNG) ENRKey() string { return "discng" }
+
+// SupportsDiscNG reports whether a node's ENR contains the discng capability flag.
+func SupportsDiscNG(n *enode.Node) bool {
+	return n.Record().Load(new(DiscNG)) == nil
+}

--- a/p2p/discover/v5_topic.go
+++ b/p2p/discover/v5_topic.go
@@ -141,10 +141,10 @@ func (reg *topicReg) registrationLoop(sys *topicSystem) {
 		}
 		time = reg.clock.Now()
 
-		// Initialize the registration state.
-		nodes := sys.transport.tab.allNodes()
+		// Initialize the registration state with DISC-NG capable nodes only.
+		nodes := filterDiscNG(sys.transport.tab.allNodes())
 		if len(nodes) == 0 {
-			continue // Local table is empty, retry later.
+			continue // No DISC-NG capable nodes, retry later.
 		}
 		shuffleNodes(nodes)
 		reg.state.AddNodes(nil, nodes)
@@ -211,7 +211,9 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 			return true
 
 		case n := <-reg.newNodesCh:
-			reg.state.AddNodes(nil, []*enode.Node{n})
+			if topicindex.SupportsDiscNG(n) {
+				reg.state.AddNodes(nil, []*enode.Node{n})
+			}
 
 		case <-updateCh:
 			attempt := reg.state.Update()
@@ -231,7 +233,7 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 
 		case resp := <-reg.regResponse:
 			if len(resp.nodes) > 0 {
-				reg.state.AddNodes(resp.att.Node, resp.nodes)
+				reg.state.AddNodes(resp.att.Node, filterDiscNG(resp.nodes))
 			}
 			if resp.err != nil {
 				reg.state.HandleErrorResponse(resp.att, resp.err)
@@ -341,7 +343,7 @@ func (s *topicSearch) runLoop(sys *topicSystem) {
 		time = s.config.Clock.Now()
 
 		state := topicindex.NewSearch(s.topic, s.config)
-		nodes := sys.transport.tab.allNodes()
+		nodes := filterDiscNG(sys.transport.tab.allNodes())
 		if len(nodes) == 0 {
 			continue
 		}
@@ -413,8 +415,8 @@ func (s *topicSearch) run(state *topicindex.Search) (exit bool) {
 
 		case queryCh <- nextQuery:
 		case resp := <-s.queryRespCh:
-			state.AddNodes(resp.src, resp.auxNodes)
-			state.AddQueryResults(resp.src, resp.topicNodes)
+			state.AddNodes(resp.src, filterDiscNG(resp.auxNodes))
+			state.AddQueryResults(resp.src, filterDiscNG(resp.topicNodes))
 			if resp.err != nil {
 				s.config.Log.Debug("TOPICQUERY/v5 failed", "topic", s.topic, "id", resp.src.ID(), "err", resp.err)
 			}
@@ -485,4 +487,15 @@ func (tsi *topicSearchIterator) Node() *enode.Node {
 
 func (tsi *topicSearchIterator) Close() {
 	tsi.closing.Do(tsi.search.stop)
+}
+
+// filterDiscNG returns only the nodes that advertise DISC-NG support in their ENR.
+func filterDiscNG(nodes []*enode.Node) []*enode.Node {
+	filtered := make([]*enode.Node, 0, len(nodes))
+	for _, n := range nodes {
+		if topicindex.SupportsDiscNG(n) {
+			filtered = append(filtered, n)
+		}
+	}
+	return filtered
 }

--- a/p2p/discover/v5_topic.go
+++ b/p2p/discover/v5_topic.go
@@ -142,7 +142,7 @@ func (reg *topicReg) registrationLoop(sys *topicSystem) {
 		time = reg.clock.Now()
 
 		// Initialize the registration state with DISC-NG capable nodes only.
-		nodes := filterDiscNG(sys.transport.tab.allNodes())
+		nodes := filterTopicDiscovery(sys.transport.tab.allNodes())
 		if len(nodes) == 0 {
 			continue // No DISC-NG capable nodes, retry later.
 		}
@@ -211,7 +211,7 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 			return true
 
 		case n := <-reg.newNodesCh:
-			if topicindex.SupportsDiscNG(n) {
+			if topicindex.SupportsTopicDiscovery(n) {
 				reg.state.AddNodes(nil, []*enode.Node{n})
 			}
 
@@ -233,7 +233,7 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 
 		case resp := <-reg.regResponse:
 			if len(resp.nodes) > 0 {
-				reg.state.AddNodes(resp.att.Node, filterDiscNG(resp.nodes))
+				reg.state.AddNodes(resp.att.Node, filterTopicDiscovery(resp.nodes))
 			}
 			if resp.err != nil {
 				reg.state.HandleErrorResponse(resp.att, resp.err)
@@ -343,7 +343,7 @@ func (s *topicSearch) runLoop(sys *topicSystem) {
 		time = s.config.Clock.Now()
 
 		state := topicindex.NewSearch(s.topic, s.config)
-		nodes := filterDiscNG(sys.transport.tab.allNodes())
+		nodes := filterTopicDiscovery(sys.transport.tab.allNodes())
 		if len(nodes) == 0 {
 			continue
 		}
@@ -415,8 +415,8 @@ func (s *topicSearch) run(state *topicindex.Search) (exit bool) {
 
 		case queryCh <- nextQuery:
 		case resp := <-s.queryRespCh:
-			state.AddNodes(resp.src, filterDiscNG(resp.auxNodes))
-			state.AddQueryResults(resp.src, filterDiscNG(resp.topicNodes))
+			state.AddNodes(resp.src, filterTopicDiscovery(resp.auxNodes))
+			state.AddQueryResults(resp.src, filterTopicDiscovery(resp.topicNodes))
 			if resp.err != nil {
 				s.config.Log.Debug("TOPICQUERY/v5 failed", "topic", s.topic, "id", resp.src.ID(), "err", resp.err)
 			}
@@ -489,11 +489,12 @@ func (tsi *topicSearchIterator) Close() {
 	tsi.closing.Do(tsi.search.stop)
 }
 
-// filterDiscNG returns only the nodes that advertise DISC-NG support in their ENR.
-func filterDiscNG(nodes []*enode.Node) []*enode.Node {
+// filterTopicDiscovery returns only the nodes that advertise a supported
+// version of the topic-discovery capability in their ENR.
+func filterTopicDiscovery(nodes []*enode.Node) []*enode.Node {
 	filtered := make([]*enode.Node, 0, len(nodes))
 	for _, n := range nodes {
-		if topicindex.SupportsDiscNG(n) {
+		if topicindex.SupportsTopicDiscovery(n) {
 			filtered = append(filtered, n)
 		}
 	}

--- a/p2p/discover/v5_topic_test.go
+++ b/p2p/discover/v5_topic_test.go
@@ -17,6 +17,7 @@
 package discover
 
 import (
+	"net"
 	"net/netip"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover/topicindex"
 	"github.com/ethereum/go-ethereum/p2p/discover/v5wire"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
 var testTopic1 = topicindex.TopicID{1, 1, 1, 1}
@@ -161,10 +163,12 @@ func TestTopicRegNodeTableUpdates(t *testing.T) {
 	key1 := newkey()
 	addr1 := netip.MustParseAddrPort("10.0.1.101:30303")
 	ln1 := test.getNode(key1, addr1)
+	ln1.Set(topicindex.DiscNG{})
 
 	key2 := newkey()
 	addr2 := netip.MustParseAddrPort("10.0.1.102:30303")
 	ln2 := test.getNode(key2, addr2)
+	ln2.Set(topicindex.DiscNG{})
 
 	test.table.addFoundNode(ln1.Node(), true)
 	test.udp.RegisterTopic(testTopic1, 1)
@@ -196,4 +200,54 @@ func TestTopicRegNodeTableUpdates(t *testing.T) {
 	if got := test.udp.topicSys.reg[testTopic1].state.NodeCount(); got != 2 {
 		t.Fatalf("wrong node count in reg state: got %d, want 2", got)
 	}
+}
+
+// TestDiscNGENRFlag verifies that the discng ENR flag is set on nodes
+// and that the filter function works correctly.
+func TestDiscNGENRFlag(t *testing.T) {
+	t.Parallel()
+
+	node := startLocalhostV5(t, Config{})
+	defer node.Close()
+
+	// The local node should have the discng ENR flag set.
+	if !topicindex.SupportsDiscNG(node.Self()) {
+		t.Fatal("local node should have discng ENR flag")
+	}
+}
+
+// TestDiscNGFilterNodes verifies that filterDiscNG correctly filters
+// nodes based on ENR capability.
+func TestDiscNGFilterNodes(t *testing.T) {
+	t.Parallel()
+
+	// Create a node with discng flag (via startLocalhostV5 which sets it).
+	withFlag := startLocalhostV5(t, Config{})
+	defer withFlag.Close()
+
+	// Create a node record without the discng flag.
+	var r enr.Record
+	r.Set(enr.IP(net.IPv4(127, 0, 0, 1)))
+	r.Set(enr.UDP(9999))
+	withoutFlag := enode.SignNull(&r, enode.ID{1, 2, 3})
+
+	nodes := []*enode.Node{withFlag.Self(), withoutFlag}
+	filtered := filterDiscNG(nodes)
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 node after filter, got %d", len(filtered))
+	}
+	if filtered[0].ID() != withFlag.Self().ID() {
+		t.Fatal("wrong node passed filter")
+	}
+}
+
+func countRegistrants(found map[enode.ID]bool, registrants map[enode.ID]bool) int {
+	count := 0
+	for id := range found {
+		if registrants[id] {
+			count++
+		}
+	}
+	return count
 }

--- a/p2p/discover/v5_topic_test.go
+++ b/p2p/discover/v5_topic_test.go
@@ -163,12 +163,12 @@ func TestTopicRegNodeTableUpdates(t *testing.T) {
 	key1 := newkey()
 	addr1 := netip.MustParseAddrPort("10.0.1.101:30303")
 	ln1 := test.getNode(key1, addr1)
-	ln1.Set(topicindex.DiscNG{})
+	ln1.Set(topicindex.TopicDiscoveryVersion)
 
 	key2 := newkey()
 	addr2 := netip.MustParseAddrPort("10.0.1.102:30303")
 	ln2 := test.getNode(key2, addr2)
-	ln2.Set(topicindex.DiscNG{})
+	ln2.Set(topicindex.TopicDiscoveryVersion)
 
 	test.table.addFoundNode(ln1.Node(), true)
 	test.udp.RegisterTopic(testTopic1, 1)
@@ -202,37 +202,36 @@ func TestTopicRegNodeTableUpdates(t *testing.T) {
 	}
 }
 
-// TestDiscNGENRFlag verifies that the discng ENR flag is set on nodes
-// and that the filter function works correctly.
-func TestDiscNGENRFlag(t *testing.T) {
+// TestTopicDiscoveryENRFlag verifies that the topic-discovery ENR entry is
+// set on nodes and that the support check works correctly.
+func TestTopicDiscoveryENRFlag(t *testing.T) {
 	t.Parallel()
 
 	node := startLocalhostV5(t, Config{})
 	defer node.Close()
 
-	// The local node should have the discng ENR flag set.
-	if !topicindex.SupportsDiscNG(node.Self()) {
-		t.Fatal("local node should have discng ENR flag")
+	if !topicindex.SupportsTopicDiscovery(node.Self()) {
+		t.Fatal("local node should advertise topic-discovery ENR entry")
 	}
 }
 
-// TestDiscNGFilterNodes verifies that filterDiscNG correctly filters
-// nodes based on ENR capability.
-func TestDiscNGFilterNodes(t *testing.T) {
+// TestTopicDiscoveryFilterNodes verifies that filterTopicDiscovery correctly
+// filters nodes based on the topic-discovery ENR capability.
+func TestTopicDiscoveryFilterNodes(t *testing.T) {
 	t.Parallel()
 
-	// Create a node with discng flag (via startLocalhostV5 which sets it).
+	// Node with topic-discovery entry (startLocalhostV5 sets it).
 	withFlag := startLocalhostV5(t, Config{})
 	defer withFlag.Close()
 
-	// Create a node record without the discng flag.
+	// Node record without the topic-discovery entry.
 	var r enr.Record
 	r.Set(enr.IP(net.IPv4(127, 0, 0, 1)))
 	r.Set(enr.UDP(9999))
 	withoutFlag := enode.SignNull(&r, enode.ID{1, 2, 3})
 
 	nodes := []*enode.Node{withFlag.Self(), withoutFlag}
-	filtered := filterDiscNG(nodes)
+	filtered := filterTopicDiscovery(nodes)
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 node after filter, got %d", len(filtered))

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -215,6 +215,8 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 	}
 	t.tab = tab
 	t.topicSys = newTopicSystem(t, topicConfig)
+	// Advertise DISC-NG capability in the local node's ENR.
+	ln.Set(topicindex.DiscNG{})
 	return t, nil
 }
 
@@ -1291,7 +1293,7 @@ func (t *UDPv5) handleTopicQuery(fromID enode.ID, fromAddr netip.AddrPort, p *v5
 
 func (t *UDPv5) collectTopicAuxNodes(topic topicindex.TopicID, reqDist []uint, remoteIP netip.Addr) []*enode.Node {
 	check := func(n *enode.Node) bool {
-		return netutil.CheckRelayAddr(remoteIP, n.IPAddr()) == nil
+		return topicindex.SupportsDiscNG(n) && netutil.CheckRelayAddr(remoteIP, n.IPAddr()) == nil
 	}
 	return t.tab.collectOnePerDist(enode.ID(topic), reqDist, regtopicNodesLimit, check)
 }

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -215,8 +215,8 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 	}
 	t.tab = tab
 	t.topicSys = newTopicSystem(t, topicConfig)
-	// Advertise DISC-NG capability in the local node's ENR.
-	ln.Set(topicindex.DiscNG{})
+	// Advertise the topic-discovery capability in the local node's ENR.
+	ln.Set(topicindex.TopicDiscoveryVersion)
 	return t, nil
 }
 
@@ -1293,7 +1293,7 @@ func (t *UDPv5) handleTopicQuery(fromID enode.ID, fromAddr netip.AddrPort, p *v5
 
 func (t *UDPv5) collectTopicAuxNodes(topic topicindex.TopicID, reqDist []uint, remoteIP netip.Addr) []*enode.Node {
 	check := func(n *enode.Node) bool {
-		return topicindex.SupportsDiscNG(n) && netutil.CheckRelayAddr(remoteIP, n.IPAddr()) == nil
+		return topicindex.SupportsTopicDiscovery(n) && netutil.CheckRelayAddr(remoteIP, n.IPAddr()) == nil
 	}
 	return t.tab.collectOnePerDist(enode.ID(topic), reqDist, regtopicNodesLimit, check)
 }


### PR DESCRIPTION
## Summary
Add an ENR entry `discng` that advertises DISC-NG topic discovery support. The topic system pre-filters nodes based on this flag to avoid sending REGTOPIC/TOPICQUERY to legacy Discv5 nodes.

## Changes
- `topicindex/common.go`: `DiscNG` ENR entry type + `SupportsDiscNG()` helper
- `v5_udp.go`: set flag on LocalNode in `newUDPv5()`
- `v5_topic.go`: `filterDiscNG()` applied in registration, search, node feed, and `collectTopicAuxNodes()`
- `v5_topic_test.go`: `TestDiscNGENRFlag`, `TestDiscNGFilterNodes`

## Test plan
- [x] ENR flag is set on node init
- [x] Nodes without flag are excluded from filter
- [x] All existing tests pass

Ref #19


---
Part of #19 (Task 2.3.1: ENR capability flag for DISC-NG support). Remaining gap tracked in #29 (DiscNG filter not applied to response-sourced nodes).
