### PR TITLE
p2p/discover: fix RegAttempt.Node data race in topicReg

### DIFF
--- a/p2p/discover/v5_topic.go
+++ b/p2p/discover/v5_topic.go
@@ -214,15 +214,19 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 			reg.state.AddNodes(nil, []*enode.Node{n})
 
 		case <-updateCh:
-			att := reg.state.Update()
-			if att != nil {
+			attempt := reg.state.Update()
+			if attempt != nil {
 				sendAttemptCh = reg.regRequest
-				nextAttempt = topicRegJob{att: att}
+				nextAttempt = topicRegJob{
+					attempt: attempt,
+					node:    attempt.Node,
+					ticket:  attempt.Ticket,
+				}
 				nextAttempt.buckets = reg.state.BucketsWithFreeSpace(nextAttempt.buckets[:0])
 			}
 
 		case sendAttemptCh <- nextAttempt:
-			reg.state.StartRequest(nextAttempt.att)
+			reg.state.StartRequest(nextAttempt.attempt)
 			sendAttemptCh = nil
 
 		case resp := <-reg.regResponse:
@@ -243,8 +247,14 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 	}
 }
 
+// topicRegJob is a dispatch job handed from the event loop to the request
+// worker. It carries a value snapshot of the attempt's node and ticket, so
+// the worker does not share *RegAttempt state with the event loop goroutine.
+// The attempt field is only used for response correlation on the way back.
 type topicRegJob struct {
-	att     *topicindex.RegAttempt
+	attempt *topicindex.RegAttempt
+	node    *enode.Node
+	ticket  []byte
 	buckets []uint
 }
 
@@ -261,10 +271,9 @@ func (reg *topicReg) runRequests(sys *topicSystem) {
 	defer reg.wg.Done()
 
 	for job := range reg.regRequest {
-		n := job.att.Node
 		topic := reg.state.Topic()
-		resp := sys.transport.regtopic(n, topic, job.att.Ticket, job.buckets, reg.opid)
-		resp.att = job.att
+		resp := sys.transport.regtopic(job.node, topic, job.ticket, job.buckets, reg.opid)
+		resp.att = job.attempt
 
 		select {
 		case reg.regResponse <- resp:


### PR DESCRIPTION
## Summary

Fix the `RegAttempt.Node` data race in `topicReg` by carrying a value snapshot of the node and ticket on the dispatch channel, so the request worker never dereferences the shared `*RegAttempt`.

## The problem

`runRequests` reads `job.att.Node` and `job.att.Ticket` through the shared `*RegAttempt` pointer that lives in the state machine's bucket map. Meanwhile the event loop can call `Registration.AddNodes` on the `newNodesCh` branch, which reassigns `attempt.Node = n` when an ENR update arrives for an in-flight attempt. Two goroutines touching the same field without synchronisation → data race per Go's memory model.

Observable impact on amd64/arm64 is minimal (the worker reads the pointer once into a local before using it), but:

- `go test -race` fails deterministically on `TestTopicRegNodeTableUpdates`.
- On 32-bit architectures, the read could be torn.
- Any future change that adds more reads of `job.att.*` would reintroduce observable incorrectness.

## The fix

Widen `topicRegJob` to carry node and ticket by value:

```go
type topicRegJob struct {
    attempt *topicindex.RegAttempt  // identity only; not dereferenced by runRequests
    node    *enode.Node              // value snapshot at dispatch
    ticket  []byte                   // value snapshot at dispatch
    buckets []uint
}
```

The event loop captures the snapshot when building `nextAttempt`. The worker uses `job.node` / `job.ticket` for the RPC call and carries `job.attempt` through only for response correlation.

No change to the state machine, the worker goroutine structure, or dispatch semantics. Registration dispatch remains serial, same as before.


## Test plan

- [x] `go vet ./p2p/discover/...` clean.
- [x] `go test -race -run 'TestTopic|TestDiscNG' ./p2p/discover/` passes.
- [x] `TestTopicRegNodeTableUpdates` (exercises the mid-registration ingress path) passes under `-race`.

Fixes #23