### PR TITLE
p2p/discover/topicindex: fix TicketSealer.Pack never reusing a key

### DIFF
--- a/p2p/discover/topicindex/ticket.go
+++ b/p2p/discover/topicindex/ticket.go
@@ -174,6 +174,7 @@ func (ts *TicketSealer) getValidKey() *ticketKey {
 		key := ts.keys[len(ts.keys)-1]
 		key.uses++
 		key.lastUsed = ts.clock.Now()
+		return key
 	}
 
 	// Generate key ID.

--- a/p2p/discover/topicindex/ticket_test.go
+++ b/p2p/discover/topicindex/ticket_test.go
@@ -71,6 +71,32 @@ func TestTicketSealerInvalid(t *testing.T) {
 
 // This test checks that tickets sealed with an older key
 // are accepted after a key rotation happened.
+// TestTicketSealerKeyReuse verifies that consecutive Pack calls reuse the
+// same signing key until ticketRekeyInterval is reached.
+func TestTicketSealerKeyReuse(t *testing.T) {
+	prevRekeyInterval := ticketRekeyInterval
+	defer func() { ticketRekeyInterval = prevRekeyInterval }()
+	ticketRekeyInterval = 10
+
+	clock := new(mclock.Simulated)
+	ts := NewTicketSealer(clock)
+
+	// Pack 25 tickets. With rekey interval 10, this should allocate
+	// exactly 3 keys: one for tickets 1..10, one for 11..20, one for 21..25.
+	for i := 0; i < 25; i++ {
+		ts.Pack(&Ticket{
+			Topic:          topic1,
+			FirstIssued:    clock.Now(),
+			WaitTimeIssued: ticketKeyLifetime - 3,
+			LastUsed:       clock.Now(),
+		})
+	}
+
+	if got, want := len(ts.keys), 3; got != want {
+		t.Fatalf("wrong number of signing keys allocated: got %d, want %d", got, want)
+	}
+}
+
 func TestTicketSealerKeyRotation(t *testing.T) {
 	prevRekeyInterval := ticketRekeyInterval
 	defer func() { ticketRekeyInterval = prevRekeyInterval }()


### PR DESCRIPTION
## Summary

`TicketSealer.getValidKey` was missing a `return key` in the "latest key still valid" branch, so `Pack` always generated a fresh HMAC key + 32 bytes of CSPRNG on every call. The `ticketRekeyInterval` contract (one key serves up to N tickets before rotation) was effectively broken — every ticket was signed with its own newly-generated key.

## Impact

- `ts.keys` grew unbounded within the 6-hour GC window — under steady REGTOPIC traffic, tens of thousands of keys accumulated.
- `Pack` burned 32 bytes of CSPRNG + an HMAC allocation per call instead of reusing the active key.
- `Unpack`'s linear scan over `ts.keys` got slower as the slice grew.
- Under DoS, memory growth scaled with attacker request rate.

Signing security is unchanged — tickets carry their own `KeyID` so verification works regardless of how many keys exist. This is a memory/CPU efficiency fix, not a correctness fix.

## Changes

- `ticket.go`: add the missing `return key` in `getValidKey`.
- `ticket_test.go`: add `TestTicketSealerKeyReuse` locking down the expected rotation count.

## Test plan

- [x] `go test -race ./p2p/discover/topicindex/` passes.
- [x] `TestTicketSealerKeyReuse` fails without the fix ("got 25, want 3") and passes with it.
- [x] `TestTicketSealerKeyRotation` continues to pass (unchanged, exercises cross-rotation Unpack).

Fixes #25