### PR TITLE
p2p/discover/topicindex: fix TopicTable.Expire evicting only one entry

### DIFF
--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -137,13 +137,17 @@ func (tab *TopicTable) NextExpiryTime() mclock.AbsTime {
 // Expire removes inactive registrations.
 func (tab *TopicTable) Expire() {
 	now := tab.config.Clock.Now()
-	for e := tab.all.Front(); e != nil; e = e.Next() {
+	// Capture Next() before remove; list.Remove nils the element's next/prev
+	// pointers, so e.Next() after remove would return nil.
+	for e := tab.all.Front(); e != nil; {
+		next := e.Next()
 		reg := e.Value.(*topicTableEntry)
 		if reg.exp > now {
 			break
 		}
 		tab.remove(reg)
 		tab.wt.removeReg(reg)
+		e = next
 	}
 }
 


### PR DESCRIPTION
## Summary

`TopicTable.Expire()` walks the table's global list and removes entries whose expiry time has passed. Due to an ordering bug in how the iterator interacts with `tab.remove`, each call evicts at most one expired entry even when many are expired.

## What Expire evicts

Each evicted item is a `topicTableEntry` — an advertisement stored when a registrant completed a REGTOPIC against this registrar. An entry is a `(node, topic)` pair with an expiry time. `tab.remove(reg)` touches three data structures:

- **`tab.all`** — the global list of all entries. Drives `AdCacheSize` accounting and the expiry scan.
- **`tab.reg[topic]`** — the per-topic list used to serve `Nodes(topic)` and `RandomNodes(topic)` (what searchers observe).
- **`tab.wt`** — the wait-time tracker's IP counter, which feeds `WaitTime(topic)` in the admission algorithm.

An evicted entry becomes invisible to searchers, releases its slot against the cache-size limit, and releases its IP quota slot.

## Bug

Go's `container/list.Remove` nils the removed element's `next` and `prev` pointers. The expire loop's increment clause `e = e.Next()` runs *after* `tab.remove(reg)` has already detached `e`, so `e.Next()` returns nil and the loop exits after a single eviction:

```go
// Buggy.
for e := tab.all.Front(); e != nil; e = e.Next() {
    reg := e.Value.(*topicTableEntry)
    if reg.exp > now { break }
    tab.remove(reg)            // detaches e; e.next becomes nil
    tab.wt.removeReg(reg)
    // loop-increment clause e = e.Next() evaluates here → nil, loop exits
}
```

### Consequences

- N simultaneously-expired entries → N separate `Expire()` calls + N scheduler wakeups instead of one of each.
- Between the first call firing and the Nth, `tab.all.Len()` still holds all-but-one of the stale entries, so `Add()` rejects new registrations as if the cache were full.
- `WaitTime(topic)` (occupancy-based) returns inflated values during the transient overshoot window.

Not a correctness failure at the eventual-consistency level — entries do get evicted, just across multiple ticks.

## Fix

Capture `Next()` before calling `remove`:

```go
for e := tab.all.Front(); e != nil; {
    next := e.Next()
    reg := e.Value.(*topicTableEntry)
    if reg.exp > now { break }
    tab.remove(reg)
    tab.wt.removeReg(reg)
    e = next
}
```

Standard "walking a linked list while mutating it" pattern.

## Verified empirically

Probe test (not part of this PR): inserting 5 entries with the same `AdLifetime`, advancing the clock past expiry, then calling `Expire()` once.

- Before fix: `tab.all.Len() = 4` — only 1 evicted.
- After fix: `tab.all.Len() = 0` — all 5 evicted in one call.

## Test plan

- [x] `go test -race ./p2p/discover/topicindex/` passes.

Fixes #26