### PR TITLE
p2p/discover: reject REGTOPIC if ENR endpoint doesn't match packet source

### DIFF
--- a/p2p/discover/v5_topic_test.go
+++ b/p2p/discover/v5_topic_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover/topicindex"
 	"github.com/ethereum/go-ethereum/p2p/discover/v5wire"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
 var testTopic1 = topicindex.TopicID{1, 1, 1, 1}
@@ -195,5 +196,56 @@ func TestTopicRegNodeTableUpdates(t *testing.T) {
 
 	if got := test.udp.topicSys.reg[testTopic1].state.NodeCount(); got != 2 {
 		t.Fatalf("wrong node count in reg state: got %d, want 2", got)
+	}
+}
+
+// TestHandleRegtopicEndpointCheck verifies that handleRegtopic rejects
+// REGTOPIC requests whose advertised ENR endpoint does not match the packet
+// source address — otherwise any peer could register an ad pointing at an
+// arbitrary IP.
+func TestHandleRegtopicEndpointCheck(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	key := newkey()
+	addrReal := netip.MustParseAddrPort("10.0.1.101:30303")
+	addrLie := netip.MustParseAddrPort("10.0.99.99:30303")
+
+	// Matching ENR: advertises the real source endpoint.
+	matchNode := test.getNode(key, addrReal)
+	matchRecord := matchNode.Node().Record()
+
+	// Mismatched ENR: same key (ID matches), but advertises a different endpoint.
+	db, _ := enode.OpenDB("")
+	defer db.Close()
+	lying := enode.NewLocalNode(db, key)
+	lying.SetStaticIP(addrLie.Addr().AsSlice())
+	lying.Set(enr.UDP(addrLie.Port()))
+	lyingRecord := lying.Node().Record()
+
+	// Case A: REGTOPIC with mismatched ENR — should be silently dropped.
+	test.packetInFrom(key, addrReal, &v5wire.Regtopic{
+		ReqID: []byte{1},
+		Topic: testTopic1,
+		ENR:   lyingRecord,
+	})
+	if nodes := test.udp.LocalTopicNodes(testTopic1); len(nodes) != 0 {
+		t.Fatalf("mismatched-endpoint REGTOPIC was accepted: %d nodes in topic", len(nodes))
+	}
+
+	// Case B: REGTOPIC with matching ENR — should be accepted and confirmed.
+	test.packetInFrom(key, addrReal, &v5wire.Regtopic{
+		ReqID: []byte{2},
+		Topic: testTopic1,
+		ENR:   matchRecord,
+	})
+	test.waitPacketOut(func(p *v5wire.Regconfirmation, addr netip.AddrPort, _ v5wire.Nonce) {
+		if addr != addrReal {
+			t.Fatalf("REGCONFIRMATION sent to wrong addr: got %v, want %v", addr, addrReal)
+		}
+	})
+	if nodes := test.udp.LocalTopicNodes(testTopic1); len(nodes) != 1 {
+		t.Fatalf("matching REGTOPIC was not stored: %d nodes in topic", len(nodes))
 	}
 }

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -1206,6 +1206,19 @@ func (t *UDPv5) handleRegtopic(fromID enode.ID, fromAddr netip.AddrPort, p *v5wi
 		t.log.Debug("Node record in REGTOPIC/v5 does not match id", "id", fromID, "addr", fromAddr)
 		return
 	}
+	// Reject ads whose advertised endpoint does not match the packet source.
+	// Without this check, any peer could register an ad pointing at an
+	// arbitrary IP, turning the topic table into a redirection vector.
+	advertised, ok := n.UDPEndpoint()
+	if !ok {
+		t.log.Debug("Node record in REGTOPIC/v5 has no UDP endpoint", "id", fromID, "addr", fromAddr)
+		return
+	}
+	if advertised != fromAddr {
+		t.log.Debug("Node record in REGTOPIC/v5 endpoint does not match packet source",
+			"id", fromID, "advertised", advertised, "from", fromAddr)
+		return
+	}
 
 	// Compute total wait time.
 	now := t.clock.Now()


### PR DESCRIPTION
## Summary

`handleRegtopic` now validates that the ENR's advertised UDP endpoint matches the packet's source address before storing the ad. Without this check, any peer with a valid key could sign an ENR advertising an arbitrary IP and have the registrar store it, enabling searchers to be redirected to unwitting victims.

This is the initial-validation half of the Task 2.2.1 peer-validation story — the periodic random revalidation of the ads / registration / search tables is tracked separately in #21.

## Changes

- `v5_udp.go`: after the existing ID check, verify `n.UDPEndpoint() == fromAddr`. Reject with a debug log otherwise, or if the ENR has no UDP endpoint.
- `v5_topic_test.go`: new `TestHandleRegtopicEndpointCheck` covers both cases (mismatch rejected, match accepted).

## Attack vector

1. Attacker controls key `A` (legitimate pair).
2. Attacker crafts ENR signed by `A` with `ip` = victim's IP, `udp` = victim's port.
3. Sends REGTOPIC from attacker's real address to registrar `R`.
4. Registrar's `handleRegtopic` — without the fix — accepts (ticket OK, ENR parses, ID matches sender).
5. Ad is stored at `R`, pointing at the victim for up to `AdLifetime` (~15 min).
6. Searchers pulling this ad connect to the victim, expecting a DISC-NG peer.

## Relation to DISC-NG paper

The paper's `REGISTER` (Algorithm 4) verifies ticket signature and ad uniqueness but doesn't require the registrar to verify the ad's advertised IP. Section 3.2 delegates endpoint validation to the DHT layer's eclipse-prevention mechanisms — in Discv5 those are PING-based and happen when populating the routing table, but `handleRegtopic` doesn't require prior routing-table membership. The paper's Validity theorem (§7.1) is not violated by a fake-IP ad because validity is defined as ticket-signature correctness, not IP truthfulness. This check enforces at admission time what the paper's threat model assumes elsewhere.

## Test plan

- [x] `go vet ./p2p/discover/...` clean.
- [x] `TestHandleRegtopicEndpointCheck` passes with the fix (mismatched REGTOPIC rejected silently; matching one stored and confirmed).
- [x] Verified the test **fails without the fix** — temporarily removed the check and confirmed the mismatched REGTOPIC was accepted, proving the regression test works.
- [x] `go test -race -run 'TestTopic|TestHandleRegtopic|TestDiscNG' -p 1 ./p2p/discover/` passes.

## Edge cases

- **NAT peers**: generally unaffected. Nodes advertise external IP/port in ENR, which matches what the registrar sees. If NAT port-rebinds mid-session, a brief rejection window is possible; subsequent retries use the fresh endpoint.
- **ENRs without UDP endpoint**: rejected separately — an ad with no reachable endpoint is not useful to store.

Fixes #24