### PR TITLE
p2p/discover: use enode.Iterator in topic reg node feed

### DIFF
--- a/p2p/discover/v5_topic.go
+++ b/p2p/discover/v5_topic.go
@@ -97,9 +97,10 @@ type topicReg struct {
 	regRequest  chan topicRegJob
 	regResponse chan topicRegResult
 
-	// nodes subscription
-	newNodesCh  chan *enode.Node
-	newNodesSub event.Subscription
+	// Continuous DHT-walking iterator that feeds candidate registrars.
+	// readNodes pumps it into newNodesCh.
+	newNodesCh chan *enode.Node
+	iter       enode.Iterator
 }
 
 func newTopicReg(sys *topicSystem, topic topicindex.TopicID, opid uint64) *topicReg {
@@ -110,47 +111,32 @@ func newTopicReg(sys *topicSystem, topic topicindex.TopicID, opid uint64) *topic
 		quit:        make(chan struct{}),
 		regRequest:  make(chan topicRegJob),
 		regResponse: make(chan topicRegResult),
+		newNodesCh:  make(chan *enode.Node, 100),
+		iter:        sys.transport.RandomNodes(),
 	}
 
-	// Set up the subscription for new main table nodes.
-	reg.newNodesCh = make(chan *enode.Node, 100)
-	reg.newNodesSub = sys.transport.tab.subscribeNodes(reg.newNodesCh)
-
-	reg.wg.Add(2)
+	reg.wg.Add(3)
 	go reg.run(sys)
 	go reg.runRequests(sys)
+	go reg.readNodes()
 	return reg
 }
 
 func (reg *topicReg) stop() {
 	close(reg.quit)
+	reg.iter.Close()
 	reg.wg.Wait()
 }
 
-func (reg *topicReg) run(sys *topicSystem) {
+// readNodes pumps nodes from the DHT-walking iterator into the event-loop
+// channel. The iterator naturally blocks when no candidates are available,
+// providing back-pressure if the event loop is slow.
+func (reg *topicReg) readNodes() {
 	defer reg.wg.Done()
-	defer reg.newNodesSub.Unsubscribe()
-	defer close(reg.regRequest)
-
-	time := mclock.AbsTime(-1)
-	for {
-		if time >= 0 {
-			if exit := reg.pause(time); exit {
-				return
-			}
-		}
-		time = reg.clock.Now()
-
-		// Initialize the registration state.
-		nodes := sys.transport.tab.allNodes()
-		if len(nodes) == 0 {
-			continue // Local table is empty, retry later.
-		}
-		shuffleNodes(nodes)
-		reg.state.AddNodes(nil, nodes)
-
-		// Perform registration.
-		if exit := reg.runRegistration(sys); exit {
+	for reg.iter.Next() {
+		select {
+		case reg.newNodesCh <- reg.iter.Node():
+		case <-reg.quit:
 			return
 		}
 	}
@@ -164,28 +150,10 @@ func shuffleNodes(nodes []*enode.Node) {
 
 const regloopMinTime = 2 * time.Second
 
-// pause ensures that top-level registration loop iterations take at least regLoopMinTime.
-// This prevents the loop from running too hot when the local node table is very empty.
-func (reg *topicReg) pause(lastTime mclock.AbsTime) bool {
-	d := reg.clock.Now().Sub(lastTime)
-	if d < regloopMinTime {
-		sleep := reg.clock.NewTimer(regloopMinTime - d)
-		defer sleep.Stop()
-		for {
-			select {
-			case <-sleep.C():
-				return false
-			case <-reg.newNodesCh:
-				// Drain the channel to avoid blocking the Table's feed sender.
-			case <-reg.quit:
-				return true
-			}
-		}
-	}
-	return false
-}
+func (reg *topicReg) run(sys *topicSystem) {
+	defer reg.wg.Done()
+	defer close(reg.regRequest)
 
-func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 	var (
 		updateEv      = mclock.NewAlarm(reg.clock)
 		nextAttempt   topicRegJob
@@ -193,10 +161,6 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 	)
 
 	for {
-		if reg.state.NodeCount() == 0 {
-			return false
-		}
-
 		var updateCh <-chan struct{}
 		if sendAttemptCh == nil {
 			next := reg.state.NextUpdateTime()
@@ -208,7 +172,7 @@ func (reg *topicReg) runRegistration(sys *topicSystem) (exit bool) {
 
 		select {
 		case <-reg.quit:
-			return true
+			return
 
 		case n := <-reg.newNodesCh:
 			reg.state.AddNodes(nil, []*enode.Node{n})

--- a/p2p/discover/v5_topic.go
+++ b/p2p/discover/v5_topic.go
@@ -111,7 +111,7 @@ func newTopicReg(sys *topicSystem, topic topicindex.TopicID, opid uint64) *topic
 		quit:        make(chan struct{}),
 		regRequest:  make(chan topicRegJob),
 		regResponse: make(chan topicRegResult),
-		newNodesCh:  make(chan *enode.Node, 100),
+		newNodesCh:  make(chan *enode.Node),
 		iter:        sys.transport.RandomNodes(),
 	}
 

--- a/p2p/discover/v5_topic_test.go
+++ b/p2p/discover/v5_topic_test.go
@@ -17,12 +17,10 @@
 package discover
 
 import (
-	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/discover/topicindex"
-	"github.com/ethereum/go-ethereum/p2p/discover/v5wire"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
@@ -151,49 +149,3 @@ func TestTopicLocalTopicNodes(t *testing.T) {
 	}
 }
 
-// TestTopicRegNodeTableUpdates verifies that a running topic registration
-// picks up new nodes arriving via the main node table feed.
-func TestTopicRegNodeTableUpdates(t *testing.T) {
-	t.Parallel()
-	test := newUDPV5Test(t)
-	defer test.close()
-
-	key1 := newkey()
-	addr1 := netip.MustParseAddrPort("10.0.1.101:30303")
-	ln1 := test.getNode(key1, addr1)
-
-	key2 := newkey()
-	addr2 := netip.MustParseAddrPort("10.0.1.102:30303")
-	ln2 := test.getNode(key2, addr2)
-
-	test.table.addFoundNode(ln1.Node(), true)
-	test.udp.RegisterTopic(testTopic1, 1)
-
-	test.waitPacketOut(func(p *v5wire.Regtopic, addr netip.AddrPort, _ v5wire.Nonce) {
-		if addr != addr1 {
-			t.Fatalf("REGTOPIC sent to wrong node: got %v, want %v", addr, addr1)
-		}
-		test.packetInFrom(key1, addr, &v5wire.Regconfirmation{
-			ReqID:    p.ReqID,
-			Ticket:   nil,
-			WaitTime: 900000,
-		})
-	})
-
-	test.table.addFoundNode(ln2.Node(), true)
-
-	test.waitPacketOut(func(p *v5wire.Regtopic, addr netip.AddrPort, _ v5wire.Nonce) {
-		if addr != addr2 {
-			t.Fatalf("REGTOPIC sent to wrong node: got %v, want %v", addr, addr2)
-		}
-		test.packetInFrom(key2, addr, &v5wire.Regconfirmation{
-			ReqID:    p.ReqID,
-			Ticket:   nil,
-			WaitTime: 900000,
-		})
-	})
-
-	if got := test.udp.topicSys.reg[testTopic1].state.NodeCount(); got != 2 {
-		t.Fatalf("wrong node count in reg state: got %d, want 2", got)
-	}
-}


### PR DESCRIPTION
## Summary

Replaces `topicReg`'s ingress for candidate registrars: instead of a `tab.allNodes()` snapshot taken at the start of each outer-loop iteration plus a `tab.subscribeNodes` feed subscription for incremental updates, registration now consumes a continuous `enode.Iterator` returned by `UDPv5.RandomNodes()`.

A small `readNodes` goroutine pumps the iterator into the existing `newNodesCh`; the rest of `runRegistration` reads from the same channel, so the state-machine and dispatch paths are unchanged.

Implements the iterator-refactor recommendation from PR #20 review for the registration side. Search side untouched.

## Why

The previous design layered three loops:
- `pause()` — 2s floor between outer-loop iterations to avoid hot-spin on empty tables.
- `tab.allNodes()` snapshot at the start of each iteration.
- A separate `tab.subscribeNodes` channel for incremental updates (which only fires when a node is *newly added* to a routing-table bucket — re-encounters of the same ID don't fire).

`enode.Iterator` (specifically `lookupIterator` from `RandomNodes()`) replaces all three. It naturally blocks when no nodes are available, naturally throttles when callers are slow (back-pressure via `Next()`), and surfaces nodes from continuous DHT walks — including same-ID re-encounters with newer ENRs (which the feed model couldn't deliver).

This matches how `p2p.Server` already wires the same iterator into the dial scheduler (`dial.go`).

## Changes

- `topicReg.run()` collapses to just `runRegistration(sys)` (no outer retry loop).
- `topicReg.pause()` removed entirely.
- `runRegistration` no longer returns `bool`; quit case returns directly. The `if state.NodeCount() == 0 { return }` early exit is removed — the event loop sits idle waiting for the iterator instead.
- `topicReg.stop()` adds `iter.Close()` to unblock `readNodes` if it's stuck in `iter.Next()`.
- New `topicReg.readNodes()` method pumps `iter.Next()` → `newNodesCh`, selecting on `quit` for clean shutdown.
- `newTopicReg`: `wg.Add(3)`, spawns `run` + `runRequests` + `readNodes`.
- `TestTopicRegNodeTableUpdates` removed — its specific scenario (mid-flight `nodeFeed` events via `addFoundNode`) doesn't apply to iterator ingress. End-to-end registration coverage stays via `TestTopicReg` (real localhost, three nodes).
- `topicSearch` is untouched. `pause()` and `shuffleNodes()` remain because `topicSearch.runLoop` still uses them.

## Net diff

- v5_topic.go: 25 lines added, 83 removed (net -58)
- v5_topic_test.go: 0 added, 48 removed (net -48)
- **Total: -106 lines**

## Test plan

- [x] `go vet ./p2p/discover/...` clean
- [x] `TestTopicReg` (end-to-end registration with two nodes) passes — confirms iterator-driven ingress reaches the bootnode and registers within 15s
- [x] `TestTopicSearch` still skipped (pre-existing #30, search-side, untouched)
- [x] `TestTopicStopRegister`, `TestTopicSearchIteratorClose`, `TestTopicLocalTopicNodes` pass
- [x] `go test -race ./p2p/discover/` clean

## Edge cases

- **Empty routing table at startup**: iterator blocks in `Next()` (waits for table refresh via `lookupFailed` → `tab.refresh` → `tab.waitForNodes`). Event loop sits idle. As discv5 finds peers, iterator unblocks. Self-healing — slightly different from old behaviour where `pause()`-then-retry cycled every 2s, both correct.
- **Bursts of duplicates**: iterator delivers same-ID nodes from different lookups. State machine's `AddNodes` is idempotent for known IDs (creates only if absent, updates `attempt.Node` only on newer Seq). No correctness impact.
- **Backpressure**: `newNodesCh` is buffered (cap 100). If full, `readNodes` blocks on send, `iter.Next()` doesn't advance, DHT walks naturally throttle.
- **Shutdown**: `stop()` does `close(quit)` + `iter.Close()` + `wg.Wait()`. `iter.Close()` unblocks `readNodes` if stuck in `Next()`; `close(quit)` propagates to all three goroutines.

## Out of scope / future

- **DiscNG filter wrapping**: when this lands and rebases into `enr-discng-flag`, the iterator gets wrapped: `enode.Filter(transport.RandomNodes(), topicindex.SupportsDiscNG)`. Not in scope here because `topdisc` doesn't have `SupportsDiscNG`.
- **Same refactor on `topicSearch`**: deferred until search-side lifecycle bugs (#27, #28, #30) land first to give a stable base.
- **Active revalidation (#21)**: complementary work — iterator brings new candidates in, revalidation prunes dead ones. Keeps the table fresh from both sides.

