### PR TITLE
p2p/discover/topicindex: fix Search.AddNodes never marking bucketCheck

### DIFF
--- a/p2p/discover/topicindex/search.go
+++ b/p2p/discover/topicindex/search.go
@@ -153,6 +153,7 @@ func (s *Search) AddNodes(src *enode.Node, nodes []*enode.Node) {
 				s.cfg.Log.Debug("Ignoring search node", "id", n.ID(), "reason", "one-per-bucket-rule")
 				continue
 			}
+			s.bucketCheck[bi] = struct{}{}
 		}
 		// Apply IP restriction.
 		ip := n.IP()

--- a/p2p/discover/topicindex/search_test.go
+++ b/p2p/discover/topicindex/search_test.go
@@ -71,6 +71,27 @@ func sbContainsAll(b searchBucket, nodes []*enode.Node) bool {
 	return true
 }
 
+// TestSearchAddNodesOnePerBucketRule verifies that within a single AddNodes
+// call from a non-nil src, at most one node is admitted to any given search
+// bucket. Regression test for an earlier bug where bucketCheck was read but
+// never written, so the rule never triggered.
+func TestSearchAddNodesOnePerBucketRule(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	src := enode.SignNull(new(enr.Record), enode.ID{})
+	// Two nodes from the same source at the same distance from the topic
+	// hash to the same search bucket. With the rule enforced, only one is
+	// kept.
+	sameBucket := nodesAtDistanceFrom(enode.ID(topic1), 250, 2, 1)
+	s.AddNodes(src, sameBucket)
+
+	bi := s.bucketIndex(sameBucket[0].ID())
+	if got := s.buckets[bi].count(); got != 1 {
+		t.Fatalf("expected 1 node in bucket[%d] under one-per-bucket-rule, got %d", bi, got)
+	}
+}
+
 // This checks (de)queueing of topic search results.
 func TestSearchResultsTracking(t *testing.T) {
 	config := testConfig(t)


### PR DESCRIPTION
## Summary

`Search.AddNodes` clears `s.bucketCheck` at the start of every call and reads from it inside the `src != nil` branch, but never writes to it. As a result, the "one-per-bucket-from-same-src" rule never triggers in topic search: a peer responding to a TOPICQUERY can return multiple aux ENRs that fall into the same client search-bucket and they all get accepted (subject only to `SearchBucketSize` and the IP-subnet cap).

`Registration.AddNodes` has both the read and the write — only `Search.AddNodes` was missing the write.

## Fix

One-line addition: `s.bucketCheck[bi] = struct{}{}` after the rejection check passes, matching the working pattern in `Registration.AddNodes`.

## Test plan

`TestSearchAddNodesOnePerBucketRule` verifies that two nodes from the same `src` falling into the same search bucket within one `AddNodes` call result in only one being kept.

- Without the fix: test fails with `expected 1 node in bucket[6] under one-per-bucket-rule, got 2`.
- With the fix: passes — second node logged as `reason=one-per-bucket-rule` and dropped.

Verified locally:
- `go test ./p2p/discover/topicindex/...` clean
- `go test ./p2p/discover/...` clean

Closes #47