### PR TITLE
p2p/discover/topicindex: limit single entry per source per bucket in topic registration table

### DIFF
--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -48,8 +48,6 @@ type Registration struct {
 	// Note: registration buckets are ordered far -> close.
 	buckets [regTableDepth]regBucket
 	heap    regHeap
-
-	bucketCheck map[int]struct{}
 }
 
 //go:generate go run golang.org/x/tools/cmd/stringer@latest -type RegAttemptState
@@ -97,6 +95,14 @@ type RegAttempt struct {
 	// reqCount tracks the number of registration requests sent.
 	reqCount int
 
+	// filledBuckets records the bucket indexes that this registrar, acting as a
+	// source of nodes, has already contributed an entry to. It enforces the
+	// 'one-per-source-per-bucket' rule across multiple responses. Because it
+	// lives on the attempt, it is freed when the registrar is evicted — so the
+	// per-source accounting is tied to the registrar's lifetime rather than
+	// accumulating forever in the buckets.
+	filledBuckets map[int]struct{}
+
 	index  int // index in regHeap
 	bucket *regBucket
 }
@@ -104,10 +110,9 @@ type RegAttempt struct {
 func NewRegistration(topic TopicID, cfg Config) *Registration {
 	cfg = cfg.withDefaults()
 	r := &Registration{
-		topic:       topic,
-		cfg:         cfg,
-		log:         cfg.Log.New("topic", topic),
-		bucketCheck: make(map[int]struct{}, regTableDepth),
+		topic: topic,
+		cfg:   cfg,
+		log:   cfg.Log.New("topic", topic),
 	}
 	dist := 256
 	for i := range r.buckets {
@@ -149,14 +154,18 @@ func (r *Registration) BucketsWithFreeSpace(dists []uint) []uint {
 
 // AddNodes notifies the registration process about found nodes.
 //
-// 'src' is the source of the nodes.
+// 'src' is the registrar that returned these nodes, or nil when they come from
+// our own routing table (bootstrap / the node feed).
 func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
-	// Clear the one-per-bucket checker.
-	for i := range r.bucketCheck {
-		delete(r.bucketCheck, i)
+	// When the nodes come from a remote registrar, find that registrar's own
+	// attempt. The 'one-per-source-per-bucket' rule is tracked on it (in
+	// filledBuckets), so the accounting is freed when the registrar is evicted
+	// instead of accumulating forever.
+	var srcAtt *RegAttempt
+	if src != nil {
+		srcAtt = r.buckets[r.bucketIndex(src.ID())].att[src.ID()]
 	}
 
-	// Add the nodes.
 	for _, n := range nodes {
 		id := n.ID()
 		if id == r.cfg.Self {
@@ -175,16 +184,14 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			continue
 		}
 
-		if src != nil {
-			// The node is supplied by a remote registrar. Enforce 'one-per-bucket' rule:
-			// in the list given by the registrar, there should be at most one node for
-			// every registration bucket. This avoids attacks where a single registrar can
-			// dominate a bucket.
-			if _, ok := r.bucketCheck[bi]; ok {
-				r.log.Debug("Ignoring registration node", "id", n.ID(), "reason", "one-per-bucket-rule")
+		// One-per-source-per-bucket rule: a registrar may contribute at most one
+		// entry to a given bucket, within a single response and across responses.
+		// This prevents a single registrar from dominating a bucket.
+		if srcAtt != nil {
+			if _, ok := srcAtt.filledBuckets[bi]; ok {
+				r.log.Debug("Ignoring registration node", "id", n.ID(), "reason", "source-already-in-bucket")
 				continue
 			}
-			r.bucketCheck[bi] = struct{}{}
 		}
 
 		if b.count[Standby] >= r.cfg.RegBucketStandbyLimit {
@@ -200,9 +207,14 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 		}
 
 		// Create a new attempt.
-		att := &RegAttempt{Node: n, bucket: b, index: -1}
+		att := &RegAttempt{Node: n, bucket: b, index: -1, filledBuckets: make(map[int]struct{})}
 		b.att[id] = att
 		b.count[att.State]++
+		// Record that the source has now filled this bucket, so a later
+		// response from the same registrar can't add another entry here.
+		if srcAtt != nil {
+			srcAtt.filledBuckets[bi] = struct{}{}
+		}
 		r.refillAttempts(att.bucket)
 	}
 }

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -95,12 +95,10 @@ type RegAttempt struct {
 	// reqCount tracks the number of registration requests sent.
 	reqCount int
 
-	// filledBuckets records the bucket indexes that this registrar, acting as a
-	// source of nodes, has already contributed an entry to. It enforces the
-	// 'one-per-source-per-bucket' rule across multiple responses. Because it
-	// lives on the attempt, it is freed when the registrar is evicted — so the
-	// per-source accounting is tied to the registrar's lifetime rather than
-	// accumulating forever in the buckets.
+	// filledBuckets records the bucket indexes that this registrar has already contributed
+	// an entry to. It enforces the 'one-per-source-per-bucket' rule across
+	// multiple responses. Because it lives on the attempt, it is freed when the
+	// registrar is evicted.
 	filledBuckets map[int]struct{}
 
 	index  int // index in regHeap
@@ -157,10 +155,7 @@ func (r *Registration) BucketsWithFreeSpace(dists []uint) []uint {
 // 'src' is the registrar that returned these nodes, or nil when they come from
 // our own routing table (bootstrap / the node feed).
 func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
-	// When the nodes come from a remote registrar, find that registrar's own
-	// attempt. The 'one-per-source-per-bucket' rule is tracked on it (in
-	// filledBuckets), so the accounting is freed when the registrar is evicted
-	// instead of accumulating forever.
+	// When the nodes come from a remote registrar, find that registrar's attempt.
 	var srcAtt *RegAttempt
 	if src != nil {
 		srcAtt = r.buckets[r.bucketIndex(src.ID())].att[src.ID()]

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -48,8 +48,6 @@ type Registration struct {
 	// Note: registration buckets are ordered far -> close.
 	buckets [regTableDepth]regBucket
 	heap    regHeap
-
-	bucketCheck map[int]struct{}
 }
 
 //go:generate go run golang.org/x/tools/cmd/stringer@latest -type RegAttemptState
@@ -63,6 +61,10 @@ type regBucket struct {
 	count [nRegStates]int
 
 	ips netutil.DistinctNetSet
+	// seenSources records which sources have ever contributed a node to this
+	// bucket during the lifetime of the Registration. It is never cleared, so
+	// a single source cannot fill a bucket across multiple AddNodes calls.
+	seenSources map[enode.ID]struct{}
 }
 
 const (
@@ -104,17 +106,17 @@ type RegAttempt struct {
 func NewRegistration(topic TopicID, cfg Config) *Registration {
 	cfg = cfg.withDefaults()
 	r := &Registration{
-		topic:       topic,
-		cfg:         cfg,
-		log:         cfg.Log.New("topic", topic),
-		bucketCheck: make(map[int]struct{}, regTableDepth),
+		topic: topic,
+		cfg:   cfg,
+		log:   cfg.Log.New("topic", topic),
 	}
 	dist := 256
 	for i := range r.buckets {
 		r.buckets[i] = regBucket{
-			att:  make(map[enode.ID]*RegAttempt),
-			dist: dist - (len(r.buckets) - 1) + i,
-			ips:  netutil.DistinctNetSet{Subnet: regBucketSubnet, Limit: regBucketIPLimit},
+			att:         make(map[enode.ID]*RegAttempt),
+			dist:        dist - (len(r.buckets) - 1) + i,
+			ips:         netutil.DistinctNetSet{Subnet: regBucketSubnet, Limit: regBucketIPLimit},
+			seenSources: make(map[enode.ID]struct{}),
 		}
 	}
 	return r
@@ -151,12 +153,6 @@ func (r *Registration) BucketsWithFreeSpace(dists []uint) []uint {
 //
 // 'src' is the source of the nodes.
 func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
-	// Clear the one-per-bucket checker.
-	for i := range r.bucketCheck {
-		delete(r.bucketCheck, i)
-	}
-
-	// Add the nodes.
 	for _, n := range nodes {
 		id := n.ID()
 		if id == r.cfg.Self {
@@ -176,15 +172,18 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 		}
 
 		if src != nil {
-			// The node is supplied by a remote registrar. Enforce 'one-per-bucket' rule:
-			// in the list given by the registrar, there should be at most one node for
-			// every registration bucket. This avoids attacks where a single registrar can
-			// dominate a bucket.
-			if _, ok := r.bucketCheck[bi]; ok {
-				r.log.Debug("Ignoring registration node", "id", n.ID(), "reason", "one-per-bucket-rule")
+			// The node is supplied by a remote registrar. Enforce a
+			// 'one-per-source-per-bucket' rule across the entire Registration
+			// lifetime: any given registrar may contribute at most one entry to
+			// a given bucket. This prevents a single registrar from dominating
+			// a bucket either within one response or across multiple responses
+			// to the same client.
+			srcID := src.ID()
+			if _, ok := b.seenSources[srcID]; ok {
+				r.log.Debug("Ignoring registration node", "id", n.ID(), "reason", "source-already-in-bucket")
 				continue
 			}
-			r.bucketCheck[bi] = struct{}{}
+			b.seenSources[srcID] = struct{}{}
 		}
 
 		if b.count[Standby] >= r.cfg.RegBucketStandbyLimit {

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -102,6 +102,47 @@ func TestRegistrationOnePerBucketCheck(t *testing.T) {
 	}
 }
 
+// TestRegistrationSourcePersistentCap verifies that a single source cannot
+// contribute more than one node to a given bucket across multiple AddNodes
+// calls. This is the persistent variant of the per-RPC one-per-bucket rule:
+// once src has contributed an entry to bucket K, subsequent calls from src
+// to that bucket are rejected, while different sources and bootstrap
+// (src == nil) calls remain admissible.
+func TestRegistrationSourcePersistentCap(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+	src1 := nodeAtDistance(enode.ID(topic1), 255, intIP(1))
+	src2 := nodeAtDistance(enode.ID(topic1), 254, intIP(2))
+
+	// First call from src1 admits one node into a bucket.
+	node1 := nodeAtDistance(enode.ID(topic1), 200, intIP(3))
+	r.AddNodes(src1, []*enode.Node{node1})
+	if r.NodeCount() != 1 {
+		t.Fatalf("after 1st call: expected 1 node, got %d", r.NodeCount())
+	}
+
+	// Second call from the same src1 to the same bucket is rejected.
+	node2 := nodeAtDistance(enode.ID(topic1), 200, intIP(4))
+	r.AddNodes(src1, []*enode.Node{node2})
+	if r.NodeCount() != 1 {
+		t.Fatalf("after 2nd call from src1 (cross-RPC cap): expected 1 node, got %d", r.NodeCount())
+	}
+
+	// A different src2 is allowed to contribute to the same bucket.
+	node3 := nodeAtDistance(enode.ID(topic1), 200, intIP(5))
+	r.AddNodes(src2, []*enode.Node{node3})
+	if r.NodeCount() != 2 {
+		t.Fatalf("after 3rd call from src2: expected 2 nodes, got %d", r.NodeCount())
+	}
+
+	// Bootstrap path (src == nil) is not subject to the cap.
+	node4 := nodeAtDistance(enode.ID(topic1), 200, intIP(6))
+	r.AddNodes(nil, []*enode.Node{node4})
+	if r.NodeCount() != 3 {
+		t.Fatalf("after bootstrap (src=nil): expected 3 nodes, got %d", r.NodeCount())
+	}
+}
+
 // This checks that the per-bucket IP limit is applied in AddNodes.
 func TestRegistrationIPCheck(t *testing.T) {
 	cfg := testConfig(t)

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -87,18 +87,123 @@ func rbContainsAll(b regBucket, nodes []*enode.Node) bool {
 	return true
 }
 
-// This checks that the one-per-bucket rule is applied in AddNodes.
+// This checks that the one-per-source-per-bucket rule is applied within a single
+// AddNodes call. The source must be a registrar in the table (the rule is
+// tracked on its attempt), which mirrors production.
 func TestRegistrationOnePerBucketCheck(t *testing.T) {
 	cfg := testConfig(t)
 	r := NewRegistration(topic1, cfg)
 	src := nodeAtDistance(enode.ID(topic1), 255, intIP(1))
+	r.AddNodes(nil, []*enode.Node{src})
 
-	// Attempt to insert multiple nodes in the same bucket.
+	// Attempt to insert multiple nodes from src into the same bucket.
 	// Only one of them should actually be added.
+	bi := r.bucketIndex(nodeAtDistance(enode.ID(topic1), 200, intIP(1)).ID())
 	nodes := nodesAtDistance(enode.ID(topic1), 200, 10)
 	r.AddNodes(src, nodes)
-	if r.NodeCount() > 1 {
-		t.Fatal("too many nodes added")
+	got := 0
+	for _, c := range r.buckets[bi].count {
+		got += c
+	}
+	if got != 1 {
+		t.Fatalf("expected 1 node in target bucket under one-per-source-per-bucket, got %d", got)
+	}
+}
+
+// TestRegistrationSourcePersistentCap verifies that a single source cannot
+// contribute more than one node to a given bucket across multiple AddNodes
+// calls. The per-source accounting lives on the source registrar's own attempt,
+// so the sources must themselves be registrars in the table — which mirrors
+// production, where the source of nodes is always a registrar we queried. Once
+// src has contributed an entry to a bucket, subsequent calls from src to that
+// bucket are rejected, while different sources and bootstrap (src == nil) calls
+// remain admissible.
+func TestRegistrationSourcePersistentCap(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+
+	// The sources must be registrars in the table for the cap to be tracked on
+	// their attempts. They land in their own (distinct) buckets.
+	src1 := nodeAtDistance(enode.ID(topic1), 255, intIP(1))
+	src2 := nodeAtDistance(enode.ID(topic1), 254, intIP(2))
+	r.AddNodes(nil, []*enode.Node{src1, src2})
+
+	// All contributed nodes share one bucket (distance 200); count entries in
+	// just that bucket so the source registrars above don't skew the totals.
+	bi := r.bucketIndex(nodeAtDistance(enode.ID(topic1), 200, intIP(3)).ID())
+	bucketCount := func() int {
+		n := 0
+		for _, c := range r.buckets[bi].count {
+			n += c
+		}
+		return n
+	}
+
+	// First call from src1 admits one node into the bucket.
+	node1 := nodeAtDistance(enode.ID(topic1), 200, intIP(3))
+	r.AddNodes(src1, []*enode.Node{node1})
+	if bucketCount() != 1 {
+		t.Fatalf("after 1st call: expected 1 node, got %d", bucketCount())
+	}
+
+	// Second call from the same src1 to the same bucket is rejected.
+	node2 := nodeAtDistance(enode.ID(topic1), 200, intIP(4))
+	r.AddNodes(src1, []*enode.Node{node2})
+	if bucketCount() != 1 {
+		t.Fatalf("after 2nd call from src1 (cross-RPC cap): expected 1 node, got %d", bucketCount())
+	}
+
+	// A different src2 is allowed to contribute to the same bucket.
+	node3 := nodeAtDistance(enode.ID(topic1), 200, intIP(5))
+	r.AddNodes(src2, []*enode.Node{node3})
+	if bucketCount() != 2 {
+		t.Fatalf("after 3rd call from src2: expected 2 nodes, got %d", bucketCount())
+	}
+
+	// Bootstrap path (src == nil) is not subject to the cap.
+	node4 := nodeAtDistance(enode.ID(topic1), 200, intIP(6))
+	r.AddNodes(nil, []*enode.Node{node4})
+	if bucketCount() != 3 {
+		t.Fatalf("after bootstrap (src=nil): expected 3 nodes, got %d", bucketCount())
+	}
+}
+
+// TestRegistrationSourceCapFreedOnEviction verifies that the per-source bucket
+// accounting is released when the source registrar is removed, so a re-added
+// registrar gets a fresh budget (the property the per-attempt design buys over
+// a never-cleared per-bucket map).
+func TestRegistrationSourceCapFreedOnEviction(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+
+	src := nodeAtDistance(enode.ID(topic1), 255, intIP(1))
+	r.AddNodes(nil, []*enode.Node{src})
+
+	bi := r.bucketIndex(nodeAtDistance(enode.ID(topic1), 200, intIP(3)).ID())
+	bucketCount := func() int {
+		n := 0
+		for _, c := range r.buckets[bi].count {
+			n += c
+		}
+		return n
+	}
+
+	// src fills the bucket once; a second entry is capped.
+	r.AddNodes(src, []*enode.Node{nodeAtDistance(enode.ID(topic1), 200, intIP(3))})
+	r.AddNodes(src, []*enode.Node{nodeAtDistance(enode.ID(topic1), 200, intIP(4))})
+	if bucketCount() != 1 {
+		t.Fatalf("expected cap to hold: want 1, got %d", bucketCount())
+	}
+
+	// Evict the source registrar. Its filledBuckets set goes with it.
+	srcBucket := &r.buckets[r.bucketIndex(src.ID())]
+	r.removeAttempt(srcBucket.att[src.ID()], "test")
+
+	// Re-add the source and let it contribute again — the cap budget is fresh.
+	r.AddNodes(nil, []*enode.Node{src})
+	r.AddNodes(src, []*enode.Node{nodeAtDistance(enode.ID(topic1), 200, intIP(7))})
+	if bucketCount() != 2 {
+		t.Fatalf("expected fresh budget after re-add: want 2, got %d", bucketCount())
 	}
 }
 


### PR DESCRIPTION
Prevents a single registrar from dominating a registration bucket: a registrar may contribute at most one entry per bucket, within a response and across responses. Tracked on the registrar's `RegAttempt` (`filledBuckets`) so it's freed when the registrar is evicted.

Closes #74
Closes #48 (duplicate of #74)
