### PR TITLE
testbed: add Docker router-based testbed

### DIFF
--- a/testbed/README.md
+++ b/testbed/README.md
@@ -54,3 +54,37 @@ If you want to re-run analysis for a past experiment, use the following command:
 ```
 testbed/analyse.py ./discv5_test_logs/<experiment>
 ```
+
+### Running modes
+
+By default, all nodes run as local processes on `127.0.0.1` (`NetworkLocal`).
+Fast, no Docker needed. IP diversity is not exercised because every node shares
+localhost.
+
+#### Docker mode
+
+Each node runs in its own Docker container with a configurable IP, optional
+bandwidth cap, and optional latency. There is no NAT and no router — each
+container literally has the IP it advertises on a single bridge network.
+
+IPs are laid out across distinct `/24`s (node N → `10.100.N.1`) so that the
+discv5 per-bucket IP-subnet cap (`regBucketSubnet=24`) is exercised meaningfully.
+
+Requires Linux with Docker (the `tc` shaping inside containers needs Linux
+kernel features that macOS Docker Desktop does not support).
+
+```
+testbed/run.py --docker --config testbed/discv5-docker-config.json --name my-test
+```
+
+##### Docker config knobs
+
+In addition to the standard config parameters, the Docker mode supports:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `minLatencyMs` / `maxLatencyMs` | Per-node egress latency, drawn uniformly from this range. Omit both for no latency shaping. | unset |
+| `minBandwidthMbit` / `maxBandwidthMbit` | Per-node egress bandwidth cap (Mbit/s), drawn uniformly. Omit both for no bandwidth shaping. | unset |
+
+Each node's per-run latency and bandwidth are sampled once at start and applied
+inside the container via `tc htb` + `tc netem` rules on `eth0`.

--- a/testbed/discv5-docker-config.json
+++ b/testbed/discv5-docker-config.json
@@ -1,0 +1,21 @@
+{
+    "nodes": 100,
+    "topic": 5,
+    "searchIterations": 3,
+    "returnedNodes": 20,
+
+    "pingInterval": 10,
+    "bucketRefreshInterval": 60,
+    "adCacheSize": 500,
+    "adLifetimeSeconds": 60,
+    "regBucketSize": 10,
+    "regBucketStandbySize": 10,
+    "searchBucketSize": 5,
+
+    "rpcSearchTimeoutSeconds": 120,
+
+    "minLatencyMs": 2,
+    "maxLatencyMs": 40,
+    "minBandwidthMbit": 100,
+    "maxBandwidthMbit": 1000
+}

--- a/testbed/docker/node/Dockerfile
+++ b/testbed/docker/node/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev linux-headers git
+
+COPY go.mod go.sum /go-ethereum/
+RUN cd /go-ethereum && go mod download
+
+COPY . /go-ethereum/
+RUN cd /go-ethereum && go build -o /devp2p ./cmd/devp2p
+
+FROM alpine:3.20
+
+RUN apk add --no-cache iproute2 bash
+COPY --from=builder /devp2p /usr/local/bin/devp2p
+COPY testbed/docker/node/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/testbed/docker/node/entrypoint.sh
+++ b/testbed/docker/node/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Apply per-node bandwidth and latency shaping if configured.
+# Both are optional. When set, NODE_BW_MBIT caps egress bandwidth and
+# NODE_LATENCY_MS adds a fixed delay on egress.
+if [ -n "$NODE_BW_MBIT" ] || [ -n "$NODE_LATENCY_MS" ]; then
+    BW=${NODE_BW_MBIT:-1000}
+    tc qdisc add dev eth0 root handle 1: htb default 11
+    tc class add dev eth0 parent 1: classid 1:11 htb rate "${BW}mbit"
+    if [ -n "$NODE_LATENCY_MS" ]; then
+        tc qdisc add dev eth0 parent 1:11 handle 10: netem delay "${NODE_LATENCY_MS}ms"
+    fi
+fi
+
+exec /usr/local/bin/devp2p "$@"

--- a/testbed/testbed/network.py
+++ b/testbed/testbed/network.py
@@ -26,9 +26,6 @@ network_config_defaults = {
     'udpBasePort': 30200,
 }
 
-MIN_LATENCY=2
-MAX_LATENCY=40
-
 class Network:
     config: dict = {}
 
@@ -37,6 +34,7 @@ class Network:
         assert isinstance(config.get('rpcBasePort'), int)
         assert isinstance(config.get('udpBasePort'), int)
         self.config = config
+        self.params: dict = {}
 
     def build(self):
         print('Compiling devp2p tool')
@@ -45,6 +43,14 @@ class Network:
 
     def stop(self):
         pass
+
+    def prepare(self, params: dict):
+        """Receives the experiment params before nodes are started.
+
+        Subclasses can override this to capture per-run configuration
+        (bandwidth, latency, etc.) needed during start_node.
+        """
+        self.params = params
 
     def node_udp_endpoint(self, node: int):
         """Returns the UDP endpoint of a node."""
@@ -112,132 +118,138 @@ class NetworkLocal(Network):
 
 
 class NetworkDocker(Network):
-    containers: list[str] = []
-    networks: list[str] = []
+    """Docker-based testbed: each node runs in its own container with a
+    configurable IP, bandwidth, and latency. No NAT, no router — every
+    container literally has the IP it advertises on a single bridge network.
+
+    IPs are laid out so that each node falls in a distinct /24 (node N -> 10.100.N.1),
+    exercising the discv5 per-bucket IP-subnet cap (regBucketSubnet=24).
+    Per-node bandwidth and latency are applied via `tc` inside each container.
+    """
+
+    DOCKER_NETWORK = 'discv5-testnet'
+    DOCKER_SUBNET = '10.100.0.0/16'
+    DOCKER_IMAGE = 'discv5-testbed-node'
+
+    def __init__(self, config=network_config_defaults):
+        super().__init__(config)
+        self.containers: list[str] = []
+        self.network_created: bool = False
 
     def build(self):
-        super().build()
+        # Remove any leftover containers/network from a previous failed run.
+        os.system('docker ps -aq --filter "name=discv5-node-" | xargs -r docker rm -f >/dev/null 2>&1 || true')
+        os.system(f'docker network rm {self.DOCKER_NETWORK} >/dev/null 2>&1 || true')
 
-        # remove stuff from previous runs
-        #os.system('docker network prune -f')
-        #os.system('docker container prune -f')
-
-        # print("Building docker container")
-        #result = os.system("docker build --tag devp2p -f Dockerfile.topdisc .")
-        #assert(result == 0)
+        print(f'Building node image: {self.DOCKER_IMAGE}')
+        result = os.system(
+            f'docker build -t {self.DOCKER_IMAGE} '
+            f'-f testbed/docker/node/Dockerfile .'
+        )
+        assert result == 0
 
     def stop(self):
         super().stop()
+        if self.containers:
+            print('Stopping containers')
+            for cid in self.containers:
+                os.system('docker kill ' + cid + ' >/dev/null 2>&1 || true')
+                os.system('docker rm ' + cid + ' >/dev/null 2>&1 || true')
+            self.containers = []
+        if self.network_created:
+            os.system(f'docker network rm {self.DOCKER_NETWORK} >/dev/null 2>&1 || true')
+            self.network_created = False
 
-        print("Stopping docker containers")
-        for container_id in self.containers:
-            os.system('docker kill ' + container_id)
-            os.system('docker rm ' + container_id)
-        self.containers = []
+    def _create_network(self):
+        argv = [
+            'docker', 'network', 'create',
+            '--driver', 'bridge',
+            '--subnet', self.DOCKER_SUBNET,
+            self.DOCKER_NETWORK,
+        ]
+        p = subprocess.run(argv, capture_output=True, text=True)
+        if p.returncode != 0:
+            print(p.stderr)
+            p.check_returncode()
+        self.network_created = True
 
-        for network_id in self.networks:
-            os.system('docker network rm ' + network_id)
-        self.networks = []
+    def _node_ip(self, node: int) -> str:
+        # /24-diverse layout: node N -> 10.100.N.1 (N in 0..255).
+        if node > 255:
+            raise ValueError(f"node index {node} exceeds /24 layout (max 256)")
+        return f'10.100.{node}.1'
 
     def node_udp_endpoint(self, node: int):
-        ip = self._node_ip(node)
-        port = self.config['udpBasePort']
-        return (ip, port)
+        return (self._node_ip(node), self.config['udpBasePort'])
 
-    # node_api_url returns the RPC URL of node n.
-    def node_api_url(self, n):
-        port = self.config['rpcBasePort']
-        ip = self._node_ip(n)
-        return "http://" + ip + ":" + str(port)
+    def node_api_url(self, node: int):
+        return f'http://{self._node_ip(node)}:{self.config["rpcBasePort"]}'
+
+    def _node_latency_ms(self, node: int):
+        lo = self.params.get('minLatencyMs')
+        hi = self.params.get('maxLatencyMs')
+        if lo is None and hi is None:
+            return None
+        if lo is None: lo = hi
+        if hi is None: hi = lo
+        return random.randint(int(lo), int(hi))
+
+    def _node_bw_mbit(self, node: int):
+        lo = self.params.get('minBandwidthMbit')
+        hi = self.params.get('maxBandwidthMbit')
+        if lo is None and hi is None:
+            return None
+        if lo is None: lo = hi
+        if hi is None: hi = lo
+        return random.randint(int(lo), int(hi))
 
     def start_node(self, node: int, bootnodes=[], nodekey=None, config_path=None):
         assert nodekey is not None
         assert config_path is not None
+        if not self.network_created:
+            self._create_network()
 
-        # create node command line
+        ip = self._node_ip(node)
         port = self.config['udpBasePort']
         rpc = self.config['rpcBasePort']
-        ip = self._node_ip(node)
-        nodeflags = [
-            "--bootnodes", ','.join(bootnodes),
-            "--nodekey", nodekey,
-            "--addr", ip+':'+str(port),
-            "--rpc", ip+':'+str(rpc),
-            "--config", "/go-ethereum/discv5-test/config.json",
-        ]
-        logfile = "/go-ethereum/discv5-test/logs/node-"+str(node)+".log"
-        logflags = ["--verbosity", "5", "--log.json", "--log.file", logfile]
-        node_args = [*logflags, "discv5", "listen", *nodeflags]
 
-        # start the docker container
+        nodeflags = [
+            '--bootnodes', ','.join(bootnodes),
+            '--nodekey', nodekey,
+            '--addr', f'{ip}:{port}',
+            '--rpc', f'{ip}:{rpc}',
+            '--config', '/work/config.json',
+        ]
+        logfile = '/work/logs/node-' + str(node) + '.log'
+        logflags = ['--verbosity', '5', '--log.json', '--log.file', logfile]
+        node_args = [*logflags, 'discv5', 'listen', *nodeflags]
+
+        env = []
+        latency = self._node_latency_ms(node)
+        if latency is not None:
+            env += ['-e', f'NODE_LATENCY_MS={latency}']
+        bw = self._node_bw_mbit(node)
+        if bw is not None:
+            env += ['-e', f'NODE_BW_MBIT={bw}']
+
         argv = [
-            "docker", "run", "-d",
-            "--name", "node"+str(node),
-            "--network", self._node_network_name(node),
-            "--cap-add", "NET_ADMIN",
-            "--mount", "type=bind,source="+config_path+",target=/go-ethereum/discv5-test",
-            "devp2p", *node_args,
+            'docker', 'run', '-d',
+            '--name', f'discv5-node-{node}',
+            '--network', self.DOCKER_NETWORK,
+            '--ip', ip,
+            '--cap-add', 'NET_ADMIN',
+            '--mount', f'type=bind,source={config_path},target=/work',
+            *env,
+            self.DOCKER_IMAGE, *node_args,
         ]
         p = subprocess.run(argv, capture_output=True, text=True)
         if p.returncode != 0:
             print(p.stderr)
             p.check_returncode()
 
-        container_id = p.stdout.split('\n')[0]
-        print('Started node', node, 'container:', container_id)
-        self.containers.append(container_id)
-        #self._config_network(n)
-
-    def create_docker_networks(self, n: int):
-        for node in range(1, n+1):
-            network = self._node_network_name(node)
-            prefix = self._node_ip_prefix(node)
-            subnet = prefix + '.0/24'
-            gateway = prefix+'.1'
-            argv = [
-                'docker', 'network', 'create', network,
-                '-d', 'bridge',
-                '--subnet=' + subnet,
-                '--gateway=' + gateway,
-            ]
-            p = subprocess.run(argv, capture_output=True, text=True)
-            if p.returncode != 0:
-                print('docker network create failed:')
-                print(p.stderr)
-            else:
-                self.networks.append(p.stdout.split('\n')[0])
-
-    def _node_network_name(self, node: int):
-        return 'node' + str(node) + '-network'
-
-    def _node_ip(self, node: int):
-        return self._node_ip_prefix(node) + '.2'
-
-    def _node_ip_prefix(self, node: int):
-        IP1=172
-        IP2=20
-        IP3=0
-        IP3=IP3+node-1
-        while IP3 > 255:
-            IP3=IP3-256
-            IP2=IP2+1
-        while IP2 > 255:
-            IP2=IP2-256
-            IP1=IP1+1
-
-        ip=str(IP1)+"."+str(IP2)+"."+str(IP3)
-        return ip
-
-    def config_network(self, node: int):
-        latency = random.randint(MIN_LATENCY,MAX_LATENCY)
-        subprocess.Popen("docker exec node"+str(node)+" sh -c 'tc qdisc add dev eth0 root netem delay "+str(latency)+"ms'", stdout=subprocess.DEVNULL, stderr=None,shell=True)
-
-        #command = 'sh -c "tc qdisc add dev eth0 root netem delay '+str(latency)+'ms"'
-        #argv = ["docker","exec","node"+str(node),command]
-        #p = subprocess.run(argv, capture_output=True, text=True)
-        #if p.returncode != 0:
-        #    print(p.stderr)
-        #    p.check_returncode()
+        cid = p.stdout.split('\n')[0]
+        print(f'Started node {node} ({ip}) container {cid[:12]}')
+        self.containers.append(cid)
 
 # _async_iter_concurrently runs fn over items. The function must return a
 # coroutine, which will be scheduled as a task.
@@ -356,10 +368,7 @@ def start_nodes(network: Network, config_path: str, params: dict):
     create_nodeid_index(config_path)
 
     print("Starting", n, "nodes...")
-
-    if isinstance(network, NetworkDocker):
-        network.create_docker_networks(n)
-        os.system("sudo iptables --flush DOCKER-ISOLATION-STAGE-1")
+    network.prepare(params)
 
     for i in range(1, n+1):
         keyfile = os.path.join(config_path, "keys", "node-"+str(i)+".key")
@@ -367,9 +376,6 @@ def start_nodes(network: Network, config_path: str, params: dict):
             nodekey = f.read()
         bn = select_bootnodes(enrs)
         network.start_node(i, bootnodes=bn, nodekey=nodekey, config_path=config_path)
-
-        if isinstance(network, NetworkDocker):
-            network.config_network(i)
 
     print("Nodes started")
 


### PR DESCRIPTION
## Summary

Replaces the existing Docker testbed in PR #18 with a simpler design that drops NAT entirely. Each node container has its actual configured IP on a single Docker bridge — no router, no virtual public IPs, no NAT classes.

## Design

| Concern | Implementation |
|---|---|
| Network topology | single bridge (`10.100.0.0/16`) |
| Container IP | real, set via `docker run --ip` |
| Per-node latency | `tc netem` inside each container |
| Per-node bandwidth | `tc htb` inside each container |
| Privileged setup | `docker run --cap-add=NET_ADMIN` per container |

IPs are laid out across distinct `/24`s (node N → `10.100.N.1`), so the per-bucket IP-subnet cap (`regBucketSubnet=24`) is exercised meaningfully.

## Files

- `testbed/docker/node/Dockerfile` — Alpine + iproute2 + the devp2p binary built from project root.
- `testbed/docker/node/entrypoint.sh` — applies `tc htb` + `tc netem` if `NODE_BW_MBIT` / `NODE_LATENCY_MS` env vars are set, then `exec`s devp2p.
- `testbed/discv5-docker-config.json` — example 100-node config with `min/maxLatencyMs` and `min/maxBandwidthMbit` ranges.
- `testbed/testbed/network.py` — `NetworkDocker` rewritten; `Network.prepare(params)` hook added so subclasses see config params before `start_node` is called.
- `testbed/README.md` — Docker-mode section added.

## What this PR does NOT include

- **NAT simulation**. If we ever need to test discv5 behaviour against NATted peers, that's a separate follow-up — not blocking real-network testing.
- **Pairwise realistic latencies**. Per-node latency is sampled uniformly from `[min, max]` per run. A follow-up will integrate the [MarcoPolo/ethereum-network-latencies](https://github.com/MarcoPolo/ethereum-network-latencies) dataset for true pairwise predicted RTTs (will likely live alongside a parallel `simnet`-based testbed).

## Test plan

- [ ] Build image: `docker build -t discv5-testbed-node -f testbed/docker/node/Dockerfile .`
- [ ] Smoke run on Linux: `testbed/run.py --docker --config testbed/discv5-docker-config.json --no-analysis --name docker-smoke`
- [ ] Verify nodes register and search across virtual IPs.
- [ ] Confirm `tc` shaping: `docker exec discv5-node-1 tc qdisc show dev eth0`
- [ ] Run analyse: `testbed/analyse.py discv5_test_logs/docker-smoke/`

Marking as draft until I've validated the smoke run on a Linux host.
