### PR TITLE
p2p/discover: observe iter.Close()/reg.stop() in in-flight topicQuery/regtopic

### DIFF
--- a/p2p/discover/v5_topic.go
+++ b/p2p/discover/v5_topic.go
@@ -272,7 +272,7 @@ func (reg *topicReg) sendRequestsLoop(sys *topicSystem) {
 
 	for job := range reg.regRequest {
 		topic := reg.state.Topic()
-		resp := sys.transport.regtopic(job.node, topic, job.ticket, job.buckets, reg.opid)
+		resp := sys.transport.regtopic(reg.quit, job.node, topic, job.ticket, job.buckets, reg.opid)
 		resp.att = job.attempt
 
 		select {
@@ -449,7 +449,7 @@ func (s *topicSearch) runRequests(sys *topicSystem) {
 	defer s.wg.Done()
 
 	for job := range s.queryCh {
-		result := sys.transport.topicQuery(job.dst, s.topic, job.buckets, s.opid)
+		result := sys.transport.topicQuery(s.quit, job.dst, s.topic, job.buckets, s.opid)
 		result.src = job.dst
 
 		select {

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -552,7 +552,9 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 }
 
 // regtopic sends REGTOPIC to node n and waits for responses.
-func (t *UDPv5) regtopic(n *enode.Node, topic topicindex.TopicID, ticket []byte, buckets []uint, opid uint64) topicRegResult {
+// regtopic sends REGTOPIC and waits for responses. The call returns early
+// with errClosed if quit is closed before all responses arrive.
+func (t *UDPv5) regtopic(quit <-chan struct{}, n *enode.Node, topic topicindex.TopicID, ticket []byte, buckets []uint, opid uint64) topicRegResult {
 	req := &v5wire.Regtopic{
 		Topic:   topic,
 		Ticket:  ticket,
@@ -573,6 +575,9 @@ func (t *UDPv5) regtopic(n *enode.Node, topic topicindex.TopicID, ticket []byte,
 	)
 	for result.err == nil && (!confirmed || (total >= 0 && received < total)) {
 		select {
+		case <-quit:
+			result.err = errClosed
+			return result
 		case responseMsg := <-c.ch:
 			switch resp := responseMsg.(type) {
 			case *v5wire.Regconfirmation:
@@ -607,8 +612,9 @@ func (t *UDPv5) regtopic(n *enode.Node, topic topicindex.TopicID, ticket []byte,
 	return result
 }
 
-// topicQuery sends TOPICQUERY and waits for responses.
-func (t *UDPv5) topicQuery(n *enode.Node, topic topicindex.TopicID, buckets []uint, opid uint64) topicQueryResult {
+// topicQuery sends TOPICQUERY and waits for responses. The call returns early
+// with errClosed if quit is closed before all responses arrive.
+func (t *UDPv5) topicQuery(quit <-chan struct{}, n *enode.Node, topic topicindex.TopicID, buckets []uint, opid uint64) topicQueryResult {
 	req := &v5wire.TopicQuery{Topic: topic, Buckets: buckets, OpID: opid}
 	c := t.callToNode(n, 0, req) // responseType=0 accepts any response type
 	defer t.callDone(c)
@@ -624,6 +630,9 @@ func (t *UDPv5) topicQuery(n *enode.Node, topic topicindex.TopicID, buckets []ui
 	)
 	for result.err == nil && (total < 0 || received < total) {
 		select {
+		case <-quit:
+			result.err = errClosed
+			return result
 		case responseMsg := <-c.ch:
 			switch resp := responseMsg.(type) {
 			case *v5wire.Nodes:


### PR DESCRIPTION
## Summary

`topicSearch.runRequests` parks inside `topicQuery`, and `topicReg.sendRequestsLoop` parks inside `regtopic`, both waiting for response packets. Without observing their respective quit channels, `iter.Close()` (search) and `StopRegisterTopic` (registration) wait until the dispatch's per-call `respTimeout` fires — up to `topicNodesResultLimit × respTimeout` (≈ 11 s search, ≈ 5.6 s reg) in the worst case for honest peers, longer under dispatch saturation.

**This is not a liveness bug** — the existing per-packet timer guarantees the loops exit eventually. The change is a cancellation-latency improvement: tighter `iter.Close()` / `StopRegisterTopic`, and bounded behaviour under dispatch overload (we saw 30+ min stalls in a 1000-node simnet experiment).

## Change

- `UDPv5.topicQuery` and `UDPv5.regtopic` now take a `quit <-chan struct{}` and add a `case <-quit:` arm to the response-wait select.
- `topicSearch.runRequests` passes `s.quit`; `topicReg.sendRequestsLoop` passes `reg.quit`.
- On cancel, both return the existing `errClosed` sentinel (no new symbol — dispatch already uses `errClosed` for similar cancellation paths at `v5_udp.go:704`, `:791`, `:796`).
- Drop the now-stale skip reason on `TestTopicSearch` referencing this issue.

## Scope kept minimal

- No new error symbol.
- No regression test (would need a partial-response stub peer; tracked separately if needed).
- 3 files / 15 insertions / 6 deletions vs `topdisc`.

Closes #30.

The broader cancellation refactor (ctx derived from `UDPv5.closeCtx`, also closing #28) is a separate piece of work — this PR only addresses cancellation latency on in-flight RPCs.