### PR TITLE
p2p/discover/topicindex: fix search deadlock and early close when empty buckets

### DIFF
--- a/p2p/discover/topicindex/search.go
+++ b/p2p/discover/topicindex/search.go
@@ -48,8 +48,6 @@ type Search struct {
 	bucketCheck  map[int]struct{}
 	resultBuffer []*enode.Node
 	resultSeen   map[enode.ID]struct{}
-
-	queriesWithoutNewNodes int
 }
 
 type searchBucket struct {
@@ -91,28 +89,22 @@ func NewSearch(topic TopicID, cfg Config) *Search {
 // this search state should be abandoned and a new search started using a
 // fresh Search instance.
 func (s *Search) IsDone() bool {
-	// TODO: what's the condition here?
-	//
-	// Ideas:
-	//
-	//   - n total results reached
-	//   - results from n sources received
-	//   - closest nodes reached (requires improved lookup tracking)
-	//   - buckets fuller than X
-
-	// The search cannot be done while there are unused results in the buffer,
-	// or while there are still nodes that could be asked.
+	// The search cannot be done while there are unused results in the buffer.
 	if len(s.resultBuffer) > 0 {
 		return false
 	}
+	// The search cannot be done while there are still nodes that could be asked.
 	for _, b := range s.buckets {
 		if len(b.new) > 0 {
 			return false
 		}
 	}
-	// No unasked nodes remain. Consider it done when the last
-	// two lookups didn't yield any new nodes.
-	return s.queriesWithoutNewNodes >= 4
+	// No unasked nodes remain and no results are buffered: the search is
+	// saturated. There is no deeper "stalled but not yet done" state to wait
+	// for, because once every bucket's `new` set is empty, QueryTarget
+	// returns nil and no further queries (and thus no further AddNodes calls
+	// that could change this state) can occur.
+	return true
 }
 
 // BucketsWithFreeSpace gives n distances from the topic at which
@@ -134,7 +126,6 @@ func (s *Search) AddNodes(src *enode.Node, nodes []*enode.Node) {
 		delete(s.bucketCheck, k)
 	}
 
-	var anyNewNode bool
 	for _, n := range nodes {
 		id := n.ID()
 		if id == s.cfg.Self {
@@ -162,14 +153,7 @@ func (s *Search) AddNodes(src *enode.Node, nodes []*enode.Node) {
 		}
 
 		// All checks passed, add the node.
-		anyNewNode = true
 		b.new[id] = n
-	}
-
-	if !anyNewNode {
-		s.queriesWithoutNewNodes++
-	} else {
-		s.queriesWithoutNewNodes = 0
 	}
 }
 

--- a/p2p/discover/topicindex/search.go
+++ b/p2p/discover/topicindex/search.go
@@ -17,6 +17,8 @@
 package topicindex
 
 import (
+	"math/rand"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
@@ -49,9 +51,10 @@ type Search struct {
 }
 
 type searchBucket struct {
-	dist  int
-	new   map[enode.ID]*enode.Node
-	asked map[enode.ID]struct{}
+	dist        int
+	new         map[enode.ID]*enode.Node
+	asked       map[enode.ID]struct{}
+	numRequests int
 
 	ips netutil.DistinctNetSet
 }
@@ -154,15 +157,31 @@ func (s *Search) AddNodes(src *enode.Node, nodes []*enode.Node) {
 	}
 }
 
-// QueryTarget returns an unasked node from the farthest non-empty bucket.
-// Buckets are walked far -> close; the current bucket is drained (including
-// any nodes added to it by AddNodes between calls) before progress advances
-// to a closer one. Empty buckets are skipped. As a result, the closest-to-
-// topic buckets are queried last, limiting load on the small set of nodes
-// responsible for the topic.
+// QueryTarget returns a random node to which a topic query should be sent.
+// The walk is gated by a warm-up frontier: only buckets with unasked nodes
+// that have received at least one response (plus the next unqueried bucket
+// with candidates) join the random pool. Empty buckets are invisible to
+// the frontier, so they do not block progress to closer buckets.
 func (s *Search) QueryTarget() *enode.Node {
+	// Collect buckets with new nodes.
+	withnew := make([]*searchBucket, 0, searchTableDepth)
 	for i := range s.buckets {
-		for _, n := range s.buckets[i].new {
+		if len(s.buckets[i].new) > 0 {
+			withnew = append(withnew, &s.buckets[i])
+			// Stop here if no request was ever sent in this bucket.
+			// This is to avoid spamming nodes close to the topic.
+			// (Empty unqueried buckets fall through: they have no
+			// candidate to warm up with, so the walk continues.)
+			if s.buckets[i].numRequests == 0 {
+				break
+			}
+		}
+	}
+
+	if len(withnew) > 0 {
+		// Select an unasked node in a random bucket.
+		b := withnew[rand.Intn(len(withnew))]
+		for _, n := range b.new {
 			return n
 		}
 	}
@@ -173,6 +192,7 @@ func (s *Search) QueryTarget() *enode.Node {
 func (s *Search) AddQueryResults(from *enode.Node, results []*enode.Node) {
 	b := s.bucket(from.ID())
 	b.setAsked(from)
+	b.numRequests++
 
 	for _, n := range results {
 		if n.ID() == s.cfg.Self {

--- a/p2p/discover/topicindex/search.go
+++ b/p2p/discover/topicindex/search.go
@@ -85,7 +85,7 @@ func NewSearch(topic TopicID, cfg Config) *Search {
 	return s
 }
 
-// IsDone reports whether the search table is saturated. When it returns true,
+// IsDone reports when the search table peers are all consumed. When it returns true,
 // this search state should be abandoned and a new search started using a
 // fresh Search instance.
 func (s *Search) IsDone() bool {
@@ -100,10 +100,7 @@ func (s *Search) IsDone() bool {
 		}
 	}
 	// No unasked nodes remain and no results are buffered: the search is
-	// saturated. There is no deeper "stalled but not yet done" state to wait
-	// for, because once every bucket's `new` set is empty, QueryTarget
-	// returns nil and no further queries (and thus no further AddNodes calls
-	// that could change this state) can occur.
+	// done. There is no more nodes to query.
 	return true
 }
 
@@ -159,10 +156,9 @@ func (s *Search) AddNodes(src *enode.Node, nodes []*enode.Node) {
 }
 
 // QueryTarget returns a random node to which a topic query should be sent.
-// The walk is gated by a warm-up frontier: only buckets with unasked nodes
-// that have received at least one response (plus the next unqueried bucket
-// with candidates) join the random pool. Empty buckets are invisible to
-// the frontier, so they do not block progress to closer buckets.
+// Random nodes are collected from buckets progressively: only buckets with unasked nodes
+// that have received at least one response, plus the next unqueried bucket
+// with candidates, join the random pool.
 func (s *Search) QueryTarget() *enode.Node {
 	// Collect buckets with new nodes.
 	withnew := make([]*searchBucket, 0, searchTableDepth)
@@ -170,9 +166,6 @@ func (s *Search) QueryTarget() *enode.Node {
 		if len(s.buckets[i].new) > 0 {
 			withnew = append(withnew, &s.buckets[i])
 			// Stop here if no request was ever sent in this bucket.
-			// This is to avoid spamming nodes close to the topic.
-			// (Empty unqueried buckets fall through: they have no
-			// candidate to warm up with, so the walk continues.)
 			if s.buckets[i].numRequests == 0 {
 				break
 			}

--- a/p2p/discover/topicindex/search.go
+++ b/p2p/discover/topicindex/search.go
@@ -17,8 +17,6 @@
 package topicindex
 
 import (
-	"math/rand"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
@@ -51,10 +49,9 @@ type Search struct {
 }
 
 type searchBucket struct {
-	dist        int
-	new         map[enode.ID]*enode.Node
-	asked       map[enode.ID]struct{}
-	numRequests int
+	dist  int
+	new   map[enode.ID]*enode.Node
+	asked map[enode.ID]struct{}
 
 	ips netutil.DistinctNetSet
 }
@@ -157,25 +154,15 @@ func (s *Search) AddNodes(src *enode.Node, nodes []*enode.Node) {
 	}
 }
 
-// QueryTarget returns a random node to which a topic query should be sent.
+// QueryTarget returns an unasked node from the farthest non-empty bucket.
+// Buckets are walked far -> close; the current bucket is drained (including
+// any nodes added to it by AddNodes between calls) before progress advances
+// to a closer one. Empty buckets are skipped. As a result, the closest-to-
+// topic buckets are queried last, limiting load on the small set of nodes
+// responsible for the topic.
 func (s *Search) QueryTarget() *enode.Node {
-	// Collect buckets with new nodes.
-	withnew := make([]*searchBucket, 0, searchTableDepth)
 	for i := range s.buckets {
-		if len(s.buckets[i].new) > 0 {
-			withnew = append(withnew, &s.buckets[i])
-		}
-		// Stop here if no request was ever sent in this bucket.
-		// This is to avoid spamming nodes close to the topic.
-		if s.buckets[i].numRequests == 0 {
-			break
-		}
-	}
-
-	if len(withnew) > 0 {
-		// Select an unasked node in a random bucket.
-		b := withnew[rand.Intn(len(withnew))]
-		for _, n := range b.new {
+		for _, n := range s.buckets[i].new {
 			return n
 		}
 	}
@@ -186,7 +173,6 @@ func (s *Search) QueryTarget() *enode.Node {
 func (s *Search) AddQueryResults(from *enode.Node, results []*enode.Node) {
 	b := s.bucket(from.ID())
 	b.setAsked(from)
-	b.numRequests++
 
 	for _, n := range results {
 		if n.ID() == s.cfg.Self {

--- a/p2p/discover/topicindex/search_test.go
+++ b/p2p/discover/topicindex/search_test.go
@@ -71,6 +71,67 @@ func sbContainsAll(b searchBucket, nodes []*enode.Node) bool {
 	return true
 }
 
+// TestSearchIsDoneNoUnaskedNodes verifies that IsDone returns true once every
+// bucket's `new` set is empty and no results are buffered. Without this, the
+// search state would deadlock: once `new` is empty across all buckets,
+// QueryTarget returns nil, no further query is sent, no AddNodes call can
+// occur, and any counter-based termination heuristic can never advance.
+// See datahop/go-ethereum#27.
+func TestSearchIsDoneNoUnaskedNodes(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	// A freshly created Search with no candidates is immediately done — the
+	// caller should roll over to a new search rather than spin.
+	if !s.IsDone() {
+		t.Fatal("IsDone should return true on an empty Search (no unasked nodes, no buffered results)")
+	}
+
+	// Seed one bucket with unasked nodes. IsDone should now be false.
+	nodes := nodesAtDistanceFrom(enode.ID(topic1), 255, 3, 1)
+	s.AddNodes(nil, nodes)
+	if s.IsDone() {
+		t.Fatal("IsDone should return false while unasked nodes remain")
+	}
+
+	// Mark every unasked node as asked. With no buffered results and no
+	// remaining `new` entries, IsDone must return true even though no query
+	// produced any new nodes (queriesWithoutNewNodes-style counters can't
+	// progress in this state).
+	for i := range s.buckets {
+		b := &s.buckets[i]
+		for id, n := range b.new {
+			b.setAsked(n)
+			delete(b.new, id)
+		}
+	}
+	if !s.IsDone() {
+		t.Fatal("IsDone should return true once all buckets are exhausted")
+	}
+}
+
+// TestSearchIsDoneBufferedResults verifies that IsDone keeps returning false
+// while buffered results have not yet been consumed by the caller, even when
+// no unasked nodes remain.
+func TestSearchIsDoneBufferedResults(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	src := nodeAtDistance(enode.ID(topic1), 255, intIP(1))
+	results := nodesAtDistanceFrom(enode.ID(topic1), 200, 2, 100)
+	s.AddQueryResults(src, results)
+
+	if s.IsDone() {
+		t.Fatal("IsDone should return false while results are buffered")
+	}
+	for range results {
+		s.PopResult()
+	}
+	if !s.IsDone() {
+		t.Fatal("IsDone should return true after all results have been popped")
+	}
+}
+
 // This checks (de)queueing of topic search results.
 func TestSearchResultsTracking(t *testing.T) {
 	config := testConfig(t)

--- a/p2p/discover/topicindex/search_test.go
+++ b/p2p/discover/topicindex/search_test.go
@@ -186,6 +186,43 @@ func TestSearchQueryTargetPrefersFarthest(t *testing.T) {
 	}
 }
 
+// TestSearchQueryTargetWidensFrontierAfterResponse verifies that the
+// warm-up frontier admits a closer bucket to the random pool once the
+// current bucket has received at least one response. Before any response,
+// only bucket 0 is in the pool; after bucket 0 is queried, both bucket 0
+// (if refilled) and bucket 5 are eligible.
+func TestSearchQueryTargetWidensFrontierAfterResponse(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	far := nodesAtDistanceFrom(enode.ID(topic1), 256, 1, 1)
+	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 1, 10)
+	s.AddNodes(nil, far)
+	s.AddNodes(nil, mid)
+
+	// Simulate a response on bucket 0: setAsked + numRequests++.
+	// This widens the frontier so bucket 5 becomes eligible.
+	s.AddQueryResults(far[0], nil)
+
+	// Refill bucket 0 so both bucket 0 and bucket 5 hold an unasked node.
+	refill := nodesAtDistanceFrom(enode.ID(topic1), 256, 1, 100)
+	s.AddNodes(nil, refill)
+
+	// Both buckets must now appear in QueryTarget picks across many calls.
+	seen := map[int]int{}
+	for i := 0; i < 200; i++ {
+		target := s.QueryTarget()
+		if target == nil {
+			t.Fatalf("QueryTarget returned nil at iter %d", i)
+		}
+		bi := s.bucketIndex(target.ID())
+		seen[bi]++
+	}
+	if seen[0] == 0 || seen[5] == 0 {
+		t.Fatalf("expected picks from both bucket[0] and bucket[5] after warm-up; got %v", seen)
+	}
+}
+
 // TestSearchQueryTargetRestartsAfterRefill verifies that newly-added far
 // nodes are picked up before further queries continue draining closer
 // buckets. Each QueryTarget call re-scans from the farthest bucket, so an

--- a/p2p/discover/topicindex/search_test.go
+++ b/p2p/discover/topicindex/search_test.go
@@ -23,37 +23,21 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
-// func TestSearchLookups(t *testing.T) {
-// 	config := testConfig(t)
-// 	s := NewSearch(topic1, config)
-//
-// 	t.Log(s.LookupTarget())
-// }
-
-// This checks that search buckets are filled correctly
-// with nodes at various distances.
-func TestSearchBuckets(t *testing.T) {
+// TestSearchBucketDistanceClamp verifies that nodes closer to the topic than
+// the table depth are clamped into the last (closest) bucket instead of being
+// dropped.
+func TestSearchBucketDistanceClamp(t *testing.T) {
 	config := testConfig(t)
 	s := NewSearch(topic1, config)
 
 	var (
-		far256  = nodesAtDistanceFrom(enode.ID(topic1), 256, 3, 1)
-		far255  = nodesAtDistanceFrom(enode.ID(topic1), 255, 3, 10)
 		close5  = nodesAtDistanceFrom(enode.ID(topic1), 5, 1, 20)
 		close20 = nodesAtDistanceFrom(enode.ID(topic1), 20, 1, 30)
 	)
-	s.AddNodes(nil, far256)
-	s.AddNodes(nil, far255)
 	s.AddNodes(nil, close5)
 	s.AddNodes(nil, close20)
 
 	last := len(s.buckets) - 1
-	if !sbContainsAll(s.buckets[0], far256) {
-		t.Fatal("far256 nodes missing in bucket[0]")
-	}
-	if !sbContainsAll(s.buckets[1], far255) {
-		t.Fatal("far255 nodes missing in bucket[1]")
-	}
 	if !sbContainsAll(s.buckets[last], close5) {
 		t.Fatalf("close5 nodes missing in bucket[%d]", last)
 	}
@@ -71,195 +55,103 @@ func sbContainsAll(b searchBucket, nodes []*enode.Node) bool {
 	return true
 }
 
-// TestSearchIsDoneNoUnaskedNodes verifies that IsDone returns true once every
-// bucket's `new` set is empty and no results are buffered. Without this, the
-// search state would deadlock: once `new` is empty across all buckets,
-// QueryTarget returns nil, no further query is sent, no AddNodes call can
-// occur, and any counter-based termination heuristic can never advance.
-// See datahop/go-ethereum#27.
-func TestSearchIsDoneNoUnaskedNodes(t *testing.T) {
+// TestSearchIsDone walks IsDone through the search lifecycle: done on a
+// fresh empty search (the caller should roll over to a new search rather
+// than spin), not done while unasked nodes remain, not done while buffered
+// results await consumption, and done again once both are exhausted.
+func TestSearchIsDone(t *testing.T) {
 	config := testConfig(t)
 	s := NewSearch(topic1, config)
 
-	// A freshly created Search with no candidates is immediately done — the
-	// caller should roll over to a new search rather than spin.
+	// A freshly created Search with no candidates is immediately done.
 	if !s.IsDone() {
 		t.Fatal("IsDone should return true on an empty Search (no unasked nodes, no buffered results)")
 	}
 
-	// Seed one bucket with unasked nodes. IsDone should now be false.
-	nodes := nodesAtDistanceFrom(enode.ID(topic1), 255, 3, 1)
-	s.AddNodes(nil, nodes)
+	// Unasked nodes keep the search running.
+	s.AddNodes(nil, nodesAtDistanceFrom(enode.ID(topic1), 255, 2, 1))
 	if s.IsDone() {
 		t.Fatal("IsDone should return false while unasked nodes remain")
 	}
 
-	// Mark every unasked node as asked. With no buffered results and no
-	// remaining `new` entries, IsDone must return true even though no query
-	// produced any new nodes (queriesWithoutNewNodes-style counters can't
-	// progress in this state).
-	for i := range s.buckets {
-		b := &s.buckets[i]
-		for id, n := range b.new {
-			b.setAsked(n)
-			delete(b.new, id)
-		}
-	}
-	if !s.IsDone() {
-		t.Fatal("IsDone should return true once all buckets are exhausted")
-	}
-}
-
-// TestSearchIsDoneBufferedResults verifies that IsDone keeps returning false
-// while buffered results have not yet been consumed by the caller, even when
-// no unasked nodes remain.
-func TestSearchIsDoneBufferedResults(t *testing.T) {
-	config := testConfig(t)
-	s := NewSearch(topic1, config)
-
-	src := nodeAtDistance(enode.ID(topic1), 255, intIP(1))
+	// Ask every node. The responses carry results, which keep the search
+	// alive even though no unasked node is left.
 	results := nodesAtDistanceFrom(enode.ID(topic1), 200, 2, 100)
-	s.AddQueryResults(src, results)
-
+	for n := s.QueryTarget(); n != nil; n = s.QueryTarget() {
+		s.AddQueryResults(n, results)
+	}
 	if s.IsDone() {
 		t.Fatal("IsDone should return false while results are buffered")
 	}
-	for range results {
+
+	// Consuming the buffered results finishes the search.
+	for s.PeekResult() != nil {
 		s.PopResult()
 	}
 	if !s.IsDone() {
-		t.Fatal("IsDone should return true after all results have been popped")
+		t.Fatal("IsDone should return true once all nodes are asked and all results consumed")
 	}
 }
 
-// TestSearchQueryTargetSkipsEmptyFarBucket verifies that QueryTarget makes
-// progress when the farthest bucket is empty: it must skip empty buckets and
-// return a node from the next non-empty one. See datahop/go-ethereum#65.
-func TestSearchQueryTargetSkipsEmptyFarBucket(t *testing.T) {
+// TestSearchQueryTarget checks how QueryTarget selects nodes: picks come
+// from the farthest bucket holding unasked candidates (empty buckets are
+// skipped), closer buckets become eligible only after that bucket has
+// received a response, and QueryTarget returns nil exactly when every node
+// has been asked.
+func TestSearchQueryTarget(t *testing.T) {
 	config := testConfig(t)
 	s := NewSearch(topic1, config)
 
-	// Populate bucket 5 (logdist 251) only. Buckets 0..4 remain empty.
-	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 3, 1)
-	s.AddNodes(nil, mid)
-
-	target := s.QueryTarget()
-	if target == nil {
-		t.Fatal("QueryTarget returned nil while bucket[5] has unasked nodes")
+	// An empty table has no target.
+	if n := s.QueryTarget(); n != nil {
+		t.Fatalf("QueryTarget on empty table returned %v, want nil", n.ID())
 	}
-	if !s.buckets[5].contains(target.ID()) {
-		t.Fatalf("QueryTarget returned node not in bucket[5]: %v", target.ID())
-	}
-}
 
-// TestSearchQueryTargetPrefersFarthest verifies that QueryTarget drains the
-// farthest non-empty bucket before advancing to closer ones. Nodes close to
-// the topic are queried last, limiting load on the small set responsible
-// for the topic.
-func TestSearchQueryTargetPrefersFarthest(t *testing.T) {
-	config := testConfig(t)
-	s := NewSearch(topic1, config)
+	// Populate buckets 3 (logdist 253) and 7 (logdist 249) with two nodes
+	// each. Buckets 0-2 and 4-6 stay empty.
+	s.AddNodes(nil, nodesAtDistanceFrom(enode.ID(topic1), 253, 2, 1))
+	s.AddNodes(nil, nodesAtDistanceFrom(enode.ID(topic1), 249, 2, 10))
 
-	far := nodesAtDistanceFrom(enode.ID(topic1), 256, 3, 1)
-	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 3, 10)
-	s.AddNodes(nil, far)
-	s.AddNodes(nil, mid)
-
-	// Drain bucket 0 entirely; every pick must come from bucket 0 first.
-	for i := 0; i < len(far); i++ {
-		target := s.QueryTarget()
-		if target == nil {
-			t.Fatalf("QueryTarget returned nil with bucket[0] still populated (iteration %d)", i)
+	// Before any response, every pick must come from bucket 3: it is the
+	// farthest bucket with candidates (the empty buckets before it are
+	// skipped), and while it has no response yet it gates the walk,
+	// keeping bucket 7 out of the pool.
+	for i := 0; i < 20; i++ {
+		n := s.QueryTarget()
+		if n == nil {
+			t.Fatal("QueryTarget returned nil on a populated table")
 		}
-		if !s.buckets[0].contains(target.ID()) {
-			t.Fatalf("iteration %d: QueryTarget returned %v from a non-farthest bucket while bucket[0] has unasked nodes", i, target.ID())
+		if bi := s.bucketIndex(n.ID()); bi != 3 {
+			t.Fatalf("pick from bucket[%d] before any response, want bucket[3]", bi)
 		}
-		s.buckets[0].setAsked(target)
 	}
-	// With bucket 0 drained, next pick must come from bucket 5.
-	target := s.QueryTarget()
-	if target == nil {
-		t.Fatal("QueryTarget returned nil after draining bucket[0] while bucket[5] is populated")
-	}
-	if !s.buckets[5].contains(target.ID()) {
-		t.Fatalf("QueryTarget returned %v after bucket[0] drained; expected a bucket[5] node", target.ID())
-	}
-}
 
-// TestSearchQueryTargetWidensFrontierAfterResponse verifies that the
-// warm-up frontier admits a closer bucket to the random pool once the
-// current bucket has received at least one response. Before any response,
-// only bucket 0 is in the pool; after bucket 0 is queried, both bucket 0
-// (if refilled) and bucket 5 are eligible.
-func TestSearchQueryTargetWidensFrontierAfterResponse(t *testing.T) {
-	config := testConfig(t)
-	s := NewSearch(topic1, config)
-
-	far := nodesAtDistanceFrom(enode.ID(topic1), 256, 1, 1)
-	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 1, 10)
-	s.AddNodes(nil, far)
-	s.AddNodes(nil, mid)
-
-	// Simulate a response on bucket 0: setAsked + numRequests++.
-	// This widens the frontier so bucket 5 becomes eligible.
-	s.AddQueryResults(far[0], nil)
-
-	// Refill bucket 0 so both bucket 0 and bucket 5 hold an unasked node.
-	refill := nodesAtDistanceFrom(enode.ID(topic1), 256, 1, 100)
-	s.AddNodes(nil, refill)
-
-	// Both buckets must now appear in QueryTarget picks across many calls.
-	seen := map[int]int{}
-	for i := 0; i < 200; i++ {
-		target := s.QueryTarget()
-		if target == nil {
-			t.Fatalf("QueryTarget returned nil at iter %d", i)
+	// Drain the table, responding to every query. The first response warms
+	// bucket 3, letting bucket 7 join the pool. Every node must be picked
+	// exactly once, and QueryTarget must return nil only at exhaustion.
+	asked := make(map[enode.ID]bool)
+	for {
+		n := s.QueryTarget()
+		if n == nil {
+			break
 		}
-		bi := s.bucketIndex(target.ID())
-		seen[bi]++
+		if asked[n.ID()] {
+			t.Fatalf("node %v picked twice", n.ID())
+		}
+		asked[n.ID()] = true
+		s.AddQueryResults(n, nil)
 	}
-	if seen[0] == 0 || seen[5] == 0 {
-		t.Fatalf("expected picks from both bucket[0] and bucket[5] after warm-up; got %v", seen)
+	if len(asked) != 4 {
+		t.Fatalf("%d nodes asked at exhaustion, want all 4", len(asked))
 	}
-}
-
-// TestSearchQueryTargetRestartsAfterRefill verifies that newly-added far
-// nodes are picked up before further queries continue draining closer
-// buckets. Each QueryTarget call re-scans from the farthest bucket, so an
-// AddNodes that lands in bucket 0 takes priority over remaining bucket-5
-// candidates.
-func TestSearchQueryTargetRestartsAfterRefill(t *testing.T) {
-	config := testConfig(t)
-	s := NewSearch(topic1, config)
-
-	// Start with bucket 5 only.
-	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 2, 1)
-	s.AddNodes(nil, mid)
-
-	first := s.QueryTarget()
-	if first == nil || !s.buckets[5].contains(first.ID()) {
-		t.Fatalf("expected first pick from bucket[5], got %v", first)
-	}
-	s.buckets[5].setAsked(first)
-
-	// Now bucket 0 receives a node. QueryTarget must prefer it over the
-	// remaining bucket-5 candidate.
-	far := nodesAtDistanceFrom(enode.ID(topic1), 256, 1, 10)
-	s.AddNodes(nil, far)
-
-	target := s.QueryTarget()
-	if target == nil {
-		t.Fatal("QueryTarget returned nil with refilled bucket[0]")
-	}
-	if !s.buckets[0].contains(target.ID()) {
-		t.Fatalf("expected pick from refilled bucket[0], got %v", target.ID())
+	if !s.IsDone() {
+		t.Fatal("IsDone should report true once every node has been asked")
 	}
 }
 
 // TestSearchAddNodesOnePerBucketRule verifies that within a single AddNodes
 // call from a non-nil src, at most one node is admitted to any given search
-// bucket. Regression test for an earlier bug where bucketCheck was read but
-// never written, so the rule never triggered.
+// bucket.
 func TestSearchAddNodesOnePerBucketRule(t *testing.T) {
 	config := testConfig(t)
 	s := NewSearch(topic1, config)
@@ -277,7 +169,8 @@ func TestSearchAddNodesOnePerBucketRule(t *testing.T) {
 	}
 }
 
-// This checks (de)queueing of topic search results.
+// This checks (de)queueing of topic search results: results come out of the
+// buffer in the order they were received.
 func TestSearchResultsTracking(t *testing.T) {
 	config := testConfig(t)
 	s := NewSearch(topic1, config)
@@ -291,8 +184,58 @@ func TestSearchResultsTracking(t *testing.T) {
 	for i, n := range nodes {
 		result := s.PeekResult()
 		if result.ID() != n.ID() {
-			t.Logf("wrong result %d: got %v, want %v", i, result.ID(), n.ID())
+			t.Fatalf("wrong result %d: got %v, want %v", i, result.ID(), n.ID())
 		}
 		s.PopResult()
+	}
+}
+
+// TestSearchBucketsWithFreeSpace verifies that BucketsWithFreeSpace reports
+// the topic distance of every bucket with room left, that a full bucket
+// drops out of the list, and that asked nodes keep occupying their slot.
+func TestSearchBucketsWithFreeSpace(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	// On a fresh table, every bucket has free space, covering the full
+	// distance range 256 .. 256-searchTableDepth+1.
+	dists := s.BucketsWithFreeSpace(nil)
+	if len(dists) != searchTableDepth {
+		t.Fatalf("fresh table reports %d buckets with free space, want %d", len(dists), searchTableDepth)
+	}
+	seen := make(map[uint]bool, len(dists))
+	for _, d := range dists {
+		seen[d] = true
+	}
+	for d := uint(256); d > uint(256-searchTableDepth); d-- {
+		if !seen[d] {
+			t.Fatalf("distance %d missing from free-space list %v", d, dists)
+		}
+	}
+
+	// Fill bucket 0 (distance 256) to capacity: it must drop out of the
+	// list while all other buckets remain.
+	full := nodesAtDistanceFrom(enode.ID(topic1), 256, s.cfg.SearchBucketSize, 1)
+	s.AddNodes(nil, full)
+	if got := s.buckets[0].count(); got != s.cfg.SearchBucketSize {
+		t.Fatalf("setup: bucket[0] holds %d nodes, want %d", got, s.cfg.SearchBucketSize)
+	}
+	dists = s.BucketsWithFreeSpace(nil)
+	if len(dists) != searchTableDepth-1 {
+		t.Fatalf("got %d buckets with free space, want %d", len(dists), searchTableDepth-1)
+	}
+	for _, d := range dists {
+		if d == 256 {
+			t.Fatal("full bucket[0] (distance 256) still reported as having free space")
+		}
+	}
+
+	// Querying a node moves it from `new` to `asked`, but it keeps
+	// occupying its slot: the bucket must remain full.
+	s.AddQueryResults(full[0], nil)
+	for _, d := range s.BucketsWithFreeSpace(nil) {
+		if d == 256 {
+			t.Fatal("bucket[0] reported free after a response; asked nodes must keep their slot")
+		}
 	}
 }

--- a/p2p/discover/topicindex/search_test.go
+++ b/p2p/discover/topicindex/search_test.go
@@ -132,6 +132,93 @@ func TestSearchIsDoneBufferedResults(t *testing.T) {
 	}
 }
 
+// TestSearchQueryTargetSkipsEmptyFarBucket verifies that QueryTarget makes
+// progress when the farthest bucket is empty: it must skip empty buckets and
+// return a node from the next non-empty one. See datahop/go-ethereum#65.
+func TestSearchQueryTargetSkipsEmptyFarBucket(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	// Populate bucket 5 (logdist 251) only. Buckets 0..4 remain empty.
+	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 3, 1)
+	s.AddNodes(nil, mid)
+
+	target := s.QueryTarget()
+	if target == nil {
+		t.Fatal("QueryTarget returned nil while bucket[5] has unasked nodes")
+	}
+	if !s.buckets[5].contains(target.ID()) {
+		t.Fatalf("QueryTarget returned node not in bucket[5]: %v", target.ID())
+	}
+}
+
+// TestSearchQueryTargetPrefersFarthest verifies that QueryTarget drains the
+// farthest non-empty bucket before advancing to closer ones. Nodes close to
+// the topic are queried last, limiting load on the small set responsible
+// for the topic.
+func TestSearchQueryTargetPrefersFarthest(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	far := nodesAtDistanceFrom(enode.ID(topic1), 256, 3, 1)
+	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 3, 10)
+	s.AddNodes(nil, far)
+	s.AddNodes(nil, mid)
+
+	// Drain bucket 0 entirely; every pick must come from bucket 0 first.
+	for i := 0; i < len(far); i++ {
+		target := s.QueryTarget()
+		if target == nil {
+			t.Fatalf("QueryTarget returned nil with bucket[0] still populated (iteration %d)", i)
+		}
+		if !s.buckets[0].contains(target.ID()) {
+			t.Fatalf("iteration %d: QueryTarget returned %v from a non-farthest bucket while bucket[0] has unasked nodes", i, target.ID())
+		}
+		s.buckets[0].setAsked(target)
+	}
+	// With bucket 0 drained, next pick must come from bucket 5.
+	target := s.QueryTarget()
+	if target == nil {
+		t.Fatal("QueryTarget returned nil after draining bucket[0] while bucket[5] is populated")
+	}
+	if !s.buckets[5].contains(target.ID()) {
+		t.Fatalf("QueryTarget returned %v after bucket[0] drained; expected a bucket[5] node", target.ID())
+	}
+}
+
+// TestSearchQueryTargetRestartsAfterRefill verifies that newly-added far
+// nodes are picked up before further queries continue draining closer
+// buckets. Each QueryTarget call re-scans from the farthest bucket, so an
+// AddNodes that lands in bucket 0 takes priority over remaining bucket-5
+// candidates.
+func TestSearchQueryTargetRestartsAfterRefill(t *testing.T) {
+	config := testConfig(t)
+	s := NewSearch(topic1, config)
+
+	// Start with bucket 5 only.
+	mid := nodesAtDistanceFrom(enode.ID(topic1), 251, 2, 1)
+	s.AddNodes(nil, mid)
+
+	first := s.QueryTarget()
+	if first == nil || !s.buckets[5].contains(first.ID()) {
+		t.Fatalf("expected first pick from bucket[5], got %v", first)
+	}
+	s.buckets[5].setAsked(first)
+
+	// Now bucket 0 receives a node. QueryTarget must prefer it over the
+	// remaining bucket-5 candidate.
+	far := nodesAtDistanceFrom(enode.ID(topic1), 256, 1, 10)
+	s.AddNodes(nil, far)
+
+	target := s.QueryTarget()
+	if target == nil {
+		t.Fatal("QueryTarget returned nil with refilled bucket[0]")
+	}
+	if !s.buckets[0].contains(target.ID()) {
+		t.Fatalf("expected pick from refilled bucket[0], got %v", target.ID())
+	}
+}
+
 // This checks (de)queueing of topic search results.
 func TestSearchResultsTracking(t *testing.T) {
 	config := testConfig(t)

--- a/p2p/discover/v5_topic_test.go
+++ b/p2p/discover/v5_topic_test.go
@@ -59,8 +59,6 @@ func TestTopicReg(t *testing.T) {
 }
 
 func TestTopicSearch(t *testing.T) {
-	t.Skip("disabled: topicSearch.runRequests can block past Close; see datahop/go-ethereum#30")
-
 	node0 := startLocalhostV5(t, Config{})
 	node1 := startLocalhostV5(t, Config{Bootnodes: []*enode.Node{node0.Self()}})
 	node2 := startLocalhostV5(t, Config{Bootnodes: []*enode.Node{node0.Self()}})
@@ -71,8 +69,11 @@ func TestTopicSearch(t *testing.T) {
 		}
 	}()
 
-	node1.topicTable.Add(node0.Self(), testTopic1)
-	node1.topicTable.Add(node3.Self(), testTopic1)
+	// Seed node1's topic table with the registrants. The topic table is
+	// owned by node1's dispatch goroutine, so the writes must be performed
+	// there (via onDispatchCh) rather than directly from the test goroutine,
+	// which would race with the dispatch loop's NextExpiryTime read.
+	seedTopicTable(t, node1, testTopic1, node0.Self(), node3.Self())
 
 	it := node2.TopicSearch(testTopic1, 0)
 	defer it.Close()
@@ -83,6 +84,25 @@ func TestTopicSearch(t *testing.T) {
 	sortByID(want)
 	if err := checkNodesEqual(found, want); err != nil {
 		t.Error(err)
+	}
+}
+
+// seedTopicTable registers the given nodes for a topic in t's local topic
+// table. The work runs on the dispatch goroutine, which owns the table.
+func seedTopicTable(t *testing.T, node *UDPv5, topic topicindex.TopicID, regs ...*enode.Node) {
+	t.Helper()
+	done := make(chan struct{})
+	fn := func() {
+		for _, n := range regs {
+			node.topicTable.Add(n, topic)
+		}
+		close(done)
+	}
+	select {
+	case node.onDispatchCh <- fn:
+		<-done
+	case <-node.closeCtx.Done():
+		t.Fatal("node closed before topic table could be seeded")
 	}
 }
 


### PR DESCRIPTION

Fix two related stalls in `Search`:

1. **`IsDone` deadlock** (closes #27): treat *no unasked nodes AND no buffered results* as the terminating condition. Drop the `queriesWithoutNewNodes >= 4` gate and the counter that backed it.

2. **`QueryTarget` empty-bucket stall** (closes #65): move the `numRequests == 0` break inside the `len(new) > 0` block so the warm-up frontier only halts on a *populated* unqueried bucket. Empty unqueried buckets are now invisible to the gate.

