### PR TITLE
p2p/discover/topicindex: drop registration when ticket WaitTime > RegAttemptTimeout and topicTableWaitTimeFloor update

### DIFF
--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -288,17 +288,26 @@ func (r *Registration) validate(att *RegAttempt) {
 // request with a ticket and waiting time.
 func (r *Registration) HandleTicketResponse(att *RegAttempt, ticket []byte, waitTime time.Duration) {
 	r.validate(att)
-	att.totalWaitTime += waitTime
 
-	// Drop the attempt when the registrar makes us wait for longer than AdLifetime. This
-	// works because the entire ad cache will have been rotated after one lifetime, and so
-	// the registrar must be misbehaving if they didn't accept
-	if att.reqCount > 1 && att.totalWaitTime > r.cfg.RegAttemptTimeout {
-		r.removeAttempt(att, "wtime-too-high")
+	// Drop the attempt when a single quote already exceeds the registrant's
+	// total budget for this (topic, registrar) pair. Waiting longer than
+	// RegAttemptTimeout on one response is strictly worse than picking
+	// another registrar — the §6 eq. 1 formula can legitimately produce
+	// values above AdLifetime under heavy contention, so AdLifetime is too
+	// aggressive a threshold here; the cumulative cap below is the real
+	// budget.
+	if waitTime > r.cfg.RegAttemptTimeout {
+		r.removeAttempt(att, "wtime-above-budget")
 		return
 	}
 
-	// TODO: should a maximum number of retries be enforced here?
+	att.totalWaitTime += waitTime
+
+	// Drop the attempt when cumulative waiting exceeds RegAttemptTimeout.
+	if att.totalWaitTime > r.cfg.RegAttemptTimeout {
+		r.removeAttempt(att, "wtime-too-high")
+		return
+	}
 
 	att.Ticket = ticket
 	att.NextTime = r.cfg.Clock.Now().Add(waitTime)

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -212,6 +212,34 @@ func TestRegistrationExpiry(t *testing.T) {
 	}
 }
 
+// TestRegistrationHandleTicketResponseDropAboveBudget verifies that a
+// registrar quoting a wait time above RegAttemptTimeout causes the attempt
+// to be dropped, freeing the bucket slot for another registrar. Without
+// this, a single packet could park the slot for the quoted duration.
+func TestRegistrationHandleTicketResponseDropAboveBudget(t *testing.T) {
+	simclock := new(mclock.Simulated)
+	cfg := testConfig(t)
+	cfg.Clock = simclock
+	cfg.AdLifetime = 15 * time.Minute
+	cfg.RegAttemptTimeout = 22*time.Minute + 30*time.Second
+	r := NewRegistration(topic1, cfg)
+
+	node := nodesAtDistance(enode.ID(r.Topic()), 30, 1)
+	r.AddNodes(nil, node)
+	att := r.Update()
+	if att == nil {
+		t.Fatal("no request scheduled")
+	}
+	r.StartRequest(att)
+
+	// Registrar quotes 49 days (well above RegAttemptTimeout). Expect the
+	// attempt to be removed from the bucket.
+	r.HandleTicketResponse(att, []byte("t"), 49*24*time.Hour)
+	if att.bucket.att[node[0].ID()] != nil {
+		t.Fatal("attempt not removed after wait time above RegAttemptTimeout")
+	}
+}
+
 // nodesAtDistance creates n nodes for which enode.LogDist(base, node.ID()) == ld.
 func nodesAtDistance(base enode.ID, ld int, n int) []*enode.Node {
 	return nodesAtDistanceFrom(base, ld, n, 1)

--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -35,7 +35,12 @@ const (
 )
 
 // If a node has less than this time to wait, they will be accepted anyway.
-const topicTableWaitTimeFloor = 50 * time.Millisecond
+// Acts as an admission slack absorbing one-way network latency, queueing
+// delay, and minor clock drift, so honest registrants whose REGTOPIC arrives
+// fractionally before the formula's requirement aren't bounced into a
+// retry. Not a security feature; the bucket-slot squat via a huge quote is
+// handled on the registrant side in registration.go.
+const topicTableWaitTimeFloor = 1 * time.Second
 
 // TopicTable holds node registrations.
 type TopicTable struct {
@@ -235,6 +240,9 @@ func (tab *TopicTable) WaitTime(n *enode.Node, t TopicID) time.Duration {
 }
 
 // Register adds node n for topic t if it has waited long enough.
+//
+// Returns 0 if the node is admitted, otherwise the new wait time the
+// registrant should observe before retrying.
 func (tab *TopicTable) Register(n *enode.Node, t TopicID, waitTime time.Duration) time.Duration {
 	// Reject attempt if node is already registered.
 	if tab.isRegistered(n, t) {


### PR DESCRIPTION
## Summary

Drop the registration attempt when a registrar quotes a ticket WaitTime greater than `RegAttemptTimeout`. A single such response would otherwise park a registration bucket slot for the quoted duration on the first round-trip — the existing cumulative `totalWaitTime > RegAttemptTimeout` check uses the accumulated sum, but one huge first quote can still push the slot into a multi-day sleep before any cumulative trip would fire.

`RegAttemptTimeout` (default 22.5 min = 1.5 × AdLifetime) is the registrant's total budget for one (topic, registrar) attempt. A single quote above that budget is, by definition, already useless to wait for — dropping is strictly better than sleeping.

`AdLifetime` would be too aggressive a threshold: the §6 eq. 1 formula can legitimately produce values above AdLifetime under heavy contention (low cache occupancy + high IP/topic-similarity), and dropping those would be a false-positive against honest registrars in contested topics.

## Changes

- `registration.go` — `HandleTicketResponse`:
  - Drop the attempt when `waitTime > RegAttemptTimeout` (new check).
  - Drop the obsolete `att.reqCount > 1` guard on the cumulative check. It existed only to let an AdLifetime-sized first quote bypass the cumulative cap; with the new per-response drop above, any first quote that survives is by definition `<= RegAttemptTimeout`, so the guard is redundant. Removing it also makes the cap correct under explicit configs with `RegAttemptTimeout < AdLifetime` (a one-bite budget the old code silently bypassed on response #1).
- `topictable.go` — bumped `topicTableWaitTimeFloor` from 50ms → 1s. This is the slack the registrar applies when a registrant's claimed wait is fractionally below the formula's requirement; 50ms was tight relative to typical wide-area one-way latency plus queueing. 1s gives honest registrants whose REGTOPIC arrives a little early due to network conditions a smoother admission path with no security implication.
- Tests: `TestRegistrationHandleTicketResponseDropAboveBudget` replaces the previous floor/ceiling clamp tests.

## Test plan

- [x] `go test ./p2p/discover/topicindex/` — package green
- [x] New test verifies the bucket slot is freed when the quoted wait exceeds `RegAttemptTimeout`
- [x] No new public API; `Config.MinWaitTime` removed

Closes #61.
