### PR TITLE
p2p/discover/v5wire: shift DISC-NG message IDs to 0x07-0x0a

### DIFF
--- a/p2p/discover/v5wire/msg.go
+++ b/p2p/discover/v5wire/msg.go
@@ -40,6 +40,13 @@ type Packet interface {
 }
 
 // Message types.
+//
+// IDs 0x07-0x0a are the DISC-NG topic-discovery messages and match the
+// wire-protocol spec (discv5/discv5-wire.md). Earlier drafts of the
+// discv5 spec reserved 0x07 / 0x08 for a separate REQUEST_TICKET /
+// TICKET pair that was never finalised; that pair has been removed
+// from the spec and from this implementation. REGCONFIRMATION now
+// carries the ticket + wait-time previously returned in TICKET.
 const (
 	PingMsg byte = iota + 1
 	PongMsg
@@ -47,8 +54,6 @@ const (
 	NodesMsg
 	TalkRequestMsg
 	TalkResponseMsg
-	RequestTicketMsg
-	TicketMsg
 	RegtopicMsg
 	RegconfirmationMsg
 	TopicQueryMsg

--- a/p2p/discover/v5wire/msg.go
+++ b/p2p/discover/v5wire/msg.go
@@ -40,13 +40,6 @@ type Packet interface {
 }
 
 // Message types.
-//
-// IDs 0x07-0x0a are the DISC-NG topic-discovery messages and match the
-// wire-protocol spec (discv5/discv5-wire.md). Earlier drafts of the
-// discv5 spec reserved 0x07 / 0x08 for a separate REQUEST_TICKET /
-// TICKET pair that was never finalised; that pair has been removed
-// from the spec and from this implementation. REGCONFIRMATION now
-// carries the ticket + wait-time previously returned in TICKET.
 const (
 	PingMsg byte = iota + 1
 	PongMsg


### PR DESCRIPTION
## Summary

Aligns the DISC-NG message IDs in `v5wire/msg.go` with the wire-protocol spec by removing the vestigial REQUEST_TICKET / TICKET (0x07 / 0x08) placeholders and shifting REGTOPIC / REGCONFIRMATION / TOPICQUERY / TOPICNODES down by two.

Companion to **datahop/devp2p#2** (the wire-spec update).

## Change

```go
// Before                              // After
RequestTicketMsg     // 0x07           PingMsg byte = iota + 1   // 0x01
TicketMsg            // 0x08           PongMsg                   // 0x02
RegtopicMsg          // 0x09           FindnodeMsg               // 0x03
RegconfirmationMsg   // 0x0a           NodesMsg                  // 0x04
TopicQueryMsg        // 0x0b           TalkRequestMsg            // 0x05
TopicNodesMsg        // 0x0c           TalkResponseMsg           // 0x06
                                       RegtopicMsg               // 0x07
                                       RegconfirmationMsg        // 0x08
                                       TopicQueryMsg             // 0x09
                                       TopicNodesMsg             // 0x0a
```

Sequence is now dense (no gaps), matching the spec at https://github.com/datahop/devp2p/blob/master/discv5/discv5-wire.md (after datahop/devp2p#2).

## Why

The `RequestTicketMsg` and `TicketMsg` slots existed only as `iota` constants — there are no struct types `RequestTicket` or `Ticket`, no encoders, no decoders, no handlers. They were inherited from earlier discv5 spec drafts that envisaged a separate two-step REGTOPIC → TICKET → REGCONFIRMATION flow. The current DISC-NG protocol merges that into a single REGCONFIRMATION response (carrying the ticket + wait-time, or empty-ticket on admission), so the placeholder slots are pure dead code that shift the live messages off the spec's sequence.

## Compatibility

**This is a wire-format change.** Peers using the old (0x09–0x0c) allocation cannot interoperate with peers using the new (0x07–0x0a) allocation on these messages.

There are no shipped deployments of the old IDs:
- The messages were still flagged "the content and semantics of this message are not final" in the wire spec until datahop/devp2p#2
- DISC-NG itself is a draft addition layered on discv5
- No production protocol traffic uses these IDs

Disruption is contained to in-development implementations.

## Test plan

- [x] `go test ./p2p/discover/v5wire/...` passes
- [x] `go test ./p2p/discover/...` passes (full topic test suite)
- [x] `go vet ./p2p/discover/...` clean
