### PR TITLE
p2p/discover/topicindex: renew registrations on expiry instead of dropping them

### DIFF
--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -255,7 +255,33 @@ func (r *Registration) Update() *RegAttempt {
 		case Standby:
 			panic("standby attempt in Registration.heap")
 		case Registered:
-			r.removeAttempt(att, "expired")
+			// This branch is reached only for a successful registration
+			// (set via HandleRegistered) whose ad has now reached its
+			// TTL. Failed attempts never get here: they are deleted at
+			// the point of failure by HandleErrorResponse and by the
+			// wait-time-too-high drop in HandleTicketResponse. So only a
+			// genuinely-valid registration is kept on expiry.
+			//
+			// On expiry, demote back to Standby instead of deleting, so
+			// the candidate registrar — still in our routing table —
+			// remains a target for renewal. Permanently removing it would
+			// drain the bucket's candidate pool, capping fan-out at
+			// ceil(register-wait / AdLifetime) candidates per registrant.
+			//
+			// Demote only while there is room in the standby pool. If the
+			// pool is already full there are enough renewal candidates, so
+			// drop this one instead and keep count[Standby] within
+			// RegBucketStandbyLimit. Either way the freed Registered slot
+			// is backfilled from standby by refillAttempts.
+			if att.bucket.count[Standby] >= r.cfg.RegBucketStandbyLimit {
+				r.removeAttempt(att, "expired")
+			} else {
+				heap.Remove(&r.heap, att.index)
+				att.Ticket = nil
+				att.totalWaitTime = 0
+				att.reqCount = 0
+				r.setAttemptState(att, Standby)
+			}
 			r.refillAttempts(att.bucket)
 		case Waiting:
 			return att

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -255,24 +255,10 @@ func (r *Registration) Update() *RegAttempt {
 		case Standby:
 			panic("standby attempt in Registration.heap")
 		case Registered:
-			// This branch is reached only for a successful registration
-			// (set via HandleRegistered) whose ad has now reached its
-			// TTL. Failed attempts never get here: they are deleted at
-			// the point of failure by HandleErrorResponse and by the
-			// wait-time-too-high drop in HandleTicketResponse. So only a
-			// genuinely-valid registration is kept on expiry.
-			//
-			// On expiry, demote back to Standby instead of deleting, so
-			// the candidate registrar — still in our routing table —
-			// remains a target for renewal. Permanently removing it would
-			// drain the bucket's candidate pool, capping fan-out at
-			// ceil(register-wait / AdLifetime) candidates per registrant.
-			//
-			// Demote only while there is room in the standby pool. If the
-			// pool is already full there are enough renewal candidates, so
-			// drop this one instead and keep count[Standby] within
-			// RegBucketStandbyLimit. Either way the freed Registered slot
-			// is backfilled from standby by refillAttempts.
+			// Ad expired: demote the registration back to Standby so its
+			// registrar stays a renewal candidate (deleting would drain the
+			// bucket's candidate pool and cap fan-out). If the standby pool is
+			// already full, drop instead. refillAttempts backfills the slot.
 			if att.bucket.count[Standby] >= r.cfg.RegBucketStandbyLimit {
 				r.removeAttempt(att, "expired")
 			} else {

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -20,9 +20,7 @@ import (
 	"math/rand"
 	"net"
 	"testing"
-	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -188,27 +186,73 @@ func TestRegistrationExpiry(t *testing.T) {
 		t.Fatal("wrong next update time:", next)
 	}
 
-	// The attempt should be removed when the ad expires.
+	// When the ad expires, the candidate should be demoted to Standby and
+	// then promoted again to Waiting via refillAttempts (renewal), so the
+	// same candidate becomes eligible for re-registration without needing
+	// AddNodes to be called again.
 	simclock.Run(cfg.AdLifetime)
-	if a := r.Update(); a != nil {
-		t.Log(spew.Sdump(a))
-		t.Fatal("Update returned an attempt, but nothing to do.")
-	}
-	if r.heap.Len() > 0 {
-		t.Fatal("attempt not removed")
-	}
-
-	// Re-add the node.
-	simclock.Run(1 * time.Second)
-	r.AddNodes(nil, node)
-
-	// It should get scheduled for registration again.
 	att = r.Update()
 	if att == nil {
-		t.Fatal("no request scheduled")
+		t.Fatal("expired Registered attempt was not re-scheduled for renewal")
 	}
 	if att.State != Waiting {
-		t.Fatal("attempt should be in state", Waiting, "but has state", att.State)
+		t.Fatal("renewed attempt should be in state", Waiting, "but has state", att.State)
+	}
+	if att.Ticket != nil {
+		t.Fatal("renewed attempt should have its ticket cleared")
+	}
+	if att.reqCount != 0 || att.totalWaitTime != 0 {
+		t.Fatal("renewed attempt should have reqCount and totalWaitTime reset")
+	}
+}
+
+// TestRegistrationExpiryDropsWhenStandbyFull checks that an expired registration
+// is dropped (not demoted) when the bucket's standby pool is already full, so the
+// standby limit is never exceeded.
+func TestRegistrationExpiryDropsWhenStandbyFull(t *testing.T) {
+	simclock := new(mclock.Simulated)
+
+	cfg := testConfig(t)
+	cfg.Clock = simclock
+	cfg.AdLifetime = 20
+	cfg.RegBucketSize = 1
+	cfg.RegBucketStandbyLimit = 2
+	r := NewRegistration(topic1, cfg)
+
+	// Three nodes in the same bucket: one becomes active (Waiting), the other
+	// two fill the standby pool to its limit.
+	nodes := nodesAtDistanceFrom(enode.ID(r.Topic()), 30, 3, 1)
+	r.AddNodes(nil, nodes)
+
+	// Register the active attempt.
+	att := r.Update()
+	if att == nil || att.State != Waiting {
+		t.Fatal("no waiting attempt scheduled")
+	}
+	registeredID := att.Node.ID()
+	r.StartRequest(att)
+	r.HandleRegistered(att, cfg.AdLifetime)
+
+	// The standby pool is full while this ad is Registered.
+	b := &r.buckets[r.bucketIndex(registeredID)]
+	if b.count[Standby] != cfg.RegBucketStandbyLimit {
+		t.Fatalf("standby=%d, want %d", b.count[Standby], cfg.RegBucketStandbyLimit)
+	}
+	before := r.NodeCount()
+
+	// On expiry, with the standby pool already full, the attempt must be
+	// dropped rather than demoted back to Standby.
+	simclock.Run(cfg.AdLifetime)
+	r.Update()
+
+	if _, ok := b.att[registeredID]; ok {
+		t.Fatal("expired attempt was not dropped despite a full standby pool")
+	}
+	if got := r.NodeCount(); got != before-1 {
+		t.Fatalf("NodeCount=%d after drop, want %d", got, before-1)
+	}
+	if b.count[Standby] > cfg.RegBucketStandbyLimit {
+		t.Fatalf("standby count %d exceeds limit %d", b.count[Standby], cfg.RegBucketStandbyLimit)
 	}
 }
 

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -153,107 +153,96 @@ func TestRegistrationRequests(t *testing.T) {
 	r.HandleRegistered(req, cfg.AdLifetime)
 }
 
-// This test checks that registration attempts expire after the lifetime
-// of the ad runs out.
+// TestRegistrationExpiry checks what happens to a Registered attempt when its
+// ad expires: it is renewed (demoted to Standby, then re-promoted to Waiting)
+// when the bucket's standby pool has room, and dropped when the pool is full.
 func TestRegistrationExpiry(t *testing.T) {
-	simclock := new(mclock.Simulated)
+	t.Run("renew when standby has room", func(t *testing.T) {
+		simclock := new(mclock.Simulated)
+		cfg := testConfig(t)
+		cfg.Clock = simclock
+		cfg.AdLifetime = 20
+		r := NewRegistration(topic1, cfg)
 
-	cfg := testConfig(t)
-	cfg.Clock = simclock
-	cfg.AdLifetime = 20
-	r := NewRegistration(topic1, cfg)
+		node := nodesAtDistance(enode.ID(r.Topic()), 30, 1)
+		r.AddNodes(nil, node)
 
-	// Deliver some nodes.
-	node := nodesAtDistance(enode.ID(r.Topic()), 30, 1)
-	r.AddNodes(nil, node)
+		att := r.Update()
+		if att == nil || att.State != Waiting {
+			t.Fatal("no waiting attempt scheduled")
+		}
+		r.StartRequest(att)
+		r.HandleRegistered(att, cfg.AdLifetime)
 
-	// A registration attempt should be created.
-	att := r.Update()
-	if att == nil {
-		t.Fatal("no request scheduled")
-	}
-	if att.State != Waiting {
-		t.Fatal("attempt should be in state", Waiting, "but has state", att.State)
-	}
+		// NextUpdateTime should now return the expiry time of the ad.
+		now := simclock.Now()
+		if next := r.NextUpdateTime(); next != now.Add(cfg.AdLifetime) {
+			t.Fatal("wrong next update time:", next)
+		}
 
-	// Mark registration to successful.
-	r.StartRequest(att)
-	r.HandleRegistered(att, cfg.AdLifetime)
+		// On expiry the candidate is demoted to Standby and re-promoted to
+		// Waiting (renewal) with its ticket/counters reset — the same candidate
+		// becomes eligible again without needing AddNodes.
+		simclock.Run(cfg.AdLifetime)
+		att = r.Update()
+		if att == nil {
+			t.Fatal("expired Registered attempt was not re-scheduled for renewal")
+		}
+		if att.State != Waiting {
+			t.Fatal("renewed attempt should be in state", Waiting, "but has state", att.State)
+		}
+		if att.Ticket != nil {
+			t.Fatal("renewed attempt should have its ticket cleared")
+		}
+		if att.reqCount != 0 || att.totalWaitTime != 0 {
+			t.Fatal("renewed attempt should have reqCount and totalWaitTime reset")
+		}
+	})
 
-	// NextUpdateTime should now return the expiry time of the ad.
-	now := simclock.Now()
-	if next := r.NextUpdateTime(); next != now.Add(cfg.AdLifetime) {
-		t.Fatal("wrong next update time:", next)
-	}
+	t.Run("drop when standby full", func(t *testing.T) {
+		simclock := new(mclock.Simulated)
+		cfg := testConfig(t)
+		cfg.Clock = simclock
+		cfg.AdLifetime = 20
+		cfg.RegBucketSize = 1
+		cfg.RegBucketStandbyLimit = 2
+		r := NewRegistration(topic1, cfg)
 
-	// When the ad expires, the candidate should be demoted to Standby and
-	// then promoted again to Waiting via refillAttempts (renewal), so the
-	// same candidate becomes eligible for re-registration without needing
-	// AddNodes to be called again.
-	simclock.Run(cfg.AdLifetime)
-	att = r.Update()
-	if att == nil {
-		t.Fatal("expired Registered attempt was not re-scheduled for renewal")
-	}
-	if att.State != Waiting {
-		t.Fatal("renewed attempt should be in state", Waiting, "but has state", att.State)
-	}
-	if att.Ticket != nil {
-		t.Fatal("renewed attempt should have its ticket cleared")
-	}
-	if att.reqCount != 0 || att.totalWaitTime != 0 {
-		t.Fatal("renewed attempt should have reqCount and totalWaitTime reset")
-	}
-}
+		// Three nodes in the same bucket: one becomes active (Waiting), the
+		// other two fill the standby pool to its limit.
+		nodes := nodesAtDistanceFrom(enode.ID(r.Topic()), 30, 3, 1)
+		r.AddNodes(nil, nodes)
 
-// TestRegistrationExpiryDropsWhenStandbyFull checks that an expired registration
-// is dropped (not demoted) when the bucket's standby pool is already full, so the
-// standby limit is never exceeded.
-func TestRegistrationExpiryDropsWhenStandbyFull(t *testing.T) {
-	simclock := new(mclock.Simulated)
+		att := r.Update()
+		if att == nil || att.State != Waiting {
+			t.Fatal("no waiting attempt scheduled")
+		}
+		registeredID := att.Node.ID()
+		r.StartRequest(att)
+		r.HandleRegistered(att, cfg.AdLifetime)
 
-	cfg := testConfig(t)
-	cfg.Clock = simclock
-	cfg.AdLifetime = 20
-	cfg.RegBucketSize = 1
-	cfg.RegBucketStandbyLimit = 2
-	r := NewRegistration(topic1, cfg)
+		// The standby pool is full while this ad is Registered.
+		b := &r.buckets[r.bucketIndex(registeredID)]
+		if b.count[Standby] != cfg.RegBucketStandbyLimit {
+			t.Fatalf("standby=%d, want %d", b.count[Standby], cfg.RegBucketStandbyLimit)
+		}
+		before := r.NodeCount()
 
-	// Three nodes in the same bucket: one becomes active (Waiting), the other
-	// two fill the standby pool to its limit.
-	nodes := nodesAtDistanceFrom(enode.ID(r.Topic()), 30, 3, 1)
-	r.AddNodes(nil, nodes)
+		// On expiry, with the standby pool already full, the attempt must be
+		// dropped rather than demoted back to Standby.
+		simclock.Run(cfg.AdLifetime)
+		r.Update()
 
-	// Register the active attempt.
-	att := r.Update()
-	if att == nil || att.State != Waiting {
-		t.Fatal("no waiting attempt scheduled")
-	}
-	registeredID := att.Node.ID()
-	r.StartRequest(att)
-	r.HandleRegistered(att, cfg.AdLifetime)
-
-	// The standby pool is full while this ad is Registered.
-	b := &r.buckets[r.bucketIndex(registeredID)]
-	if b.count[Standby] != cfg.RegBucketStandbyLimit {
-		t.Fatalf("standby=%d, want %d", b.count[Standby], cfg.RegBucketStandbyLimit)
-	}
-	before := r.NodeCount()
-
-	// On expiry, with the standby pool already full, the attempt must be
-	// dropped rather than demoted back to Standby.
-	simclock.Run(cfg.AdLifetime)
-	r.Update()
-
-	if _, ok := b.att[registeredID]; ok {
-		t.Fatal("expired attempt was not dropped despite a full standby pool")
-	}
-	if got := r.NodeCount(); got != before-1 {
-		t.Fatalf("NodeCount=%d after drop, want %d", got, before-1)
-	}
-	if b.count[Standby] > cfg.RegBucketStandbyLimit {
-		t.Fatalf("standby count %d exceeds limit %d", b.count[Standby], cfg.RegBucketStandbyLimit)
-	}
+		if _, ok := b.att[registeredID]; ok {
+			t.Fatal("expired attempt was not dropped despite a full standby pool")
+		}
+		if got := r.NodeCount(); got != before-1 {
+			t.Fatalf("NodeCount=%d after drop, want %d", got, before-1)
+		}
+		if b.count[Standby] > cfg.RegBucketStandbyLimit {
+			t.Fatalf("standby count %d exceeds limit %d", b.count[Standby], cfg.RegBucketStandbyLimit)
+		}
+	})
 }
 
 // nodesAtDistance creates n nodes for which enode.LogDist(base, node.ID()) == ld.


### PR DESCRIPTION

When a `Registered` attempt's ad reaches its TTL, `Registration.Update` removed the attempt outright (`removeAttempt(att, "expired")`). Because removal deletes the candidate from the bucket entirely, that registrar needs to be rediscovered for a new registration. A better approach is to keep them on the standby list in case not full, without requiring rediscovery for known nodes.

