### PR TITLE
p2p/discover: handle callDone for a queued call instead of panicing

### DIFF
--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -776,7 +776,28 @@ func (t *UDPv5) dispatch() {
 		case c := <-t.callDoneCh:
 			active := t.activeCallByNode[c.id]
 			if active != c {
-				panic("BUG: callDone for inactive call")
+				// c is not the active call for c.id. This happens when a call
+				// was still waiting in callQueue (behind another active call to
+				// the same node) and its caller returned early — e.g. a
+				// TOPICQUERY/REGTOPIC whose quit channel fired on iter.Close /
+				// reg.stop. Such a call was never sent, so c.timeout is nil and
+				// the activeCall* maps don't reference it. Remove it from the
+				// queue so it isn't sent later, and skip the active-call cleanup.
+				if c.timeout != nil {
+					c.timeout.Stop()
+				}
+				if q := t.callQueue[c.id]; len(q) > 0 {
+					for i, qc := range q {
+						if qc == c {
+							t.callQueue[c.id] = append(q[:i], q[i+1:]...)
+							if len(t.callQueue[c.id]) == 0 {
+								delete(t.callQueue, c.id)
+							}
+							break
+						}
+					}
+				}
+				continue
 			}
 			c.timeout.Stop()
 			delete(t.activeCallByAuth, c.nonce)

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -100,7 +100,7 @@ type UDPv5 struct {
 	topicSys     *topicSystem
 
 	// channels into dispatch
-	onDispatchCh chan func()
+	onDispatchCh  chan func()
 	packetInCh    chan ReadPacket
 	readNextCh    chan struct{}
 	callCh        chan *callV5
@@ -774,35 +774,28 @@ func (t *UDPv5) dispatch() {
 			}
 
 		case c := <-t.callDoneCh:
-			active := t.activeCallByNode[c.id]
-			if active != c {
-				// c is not the active call for c.id. This happens when a call
-				// was still waiting in callQueue (behind another active call to
-				// the same node) and its caller returned early — e.g. a
-				// TOPICQUERY/REGTOPIC whose quit channel fired on iter.Close /
-				// reg.stop. Such a call was never sent, so c.timeout is nil and
-				// the activeCall* maps don't reference it. Remove it from the
-				// queue so it isn't sent later, and skip the active-call cleanup.
-				if c.timeout != nil {
-					c.timeout.Stop()
-				}
-				if q := t.callQueue[c.id]; len(q) > 0 {
-					for i, qc := range q {
-						if qc == c {
-							t.callQueue[c.id] = append(q[:i], q[i+1:]...)
-							if len(t.callQueue[c.id]) == 0 {
-								delete(t.callQueue, c.id)
-							}
-							break
-						}
-					}
-				}
-				continue
+			// A call reported done must be in exactly one of two states: the
+			// active call for its node, or still parked in callQueue.
+			// remove call or panic if not found.
+			isActive := t.activeCallByNode[c.id] == c
+			qi := slices.Index(t.callQueue[c.id], c)
+			inQueue := qi >= 0
+			if isActive == inQueue {
+				panic(fmt.Sprintf("BUG: callDone: call must be either active or queued (active=%v queued=%v)", isActive, inQueue))
 			}
-			c.timeout.Stop()
-			delete(t.activeCallByAuth, c.nonce)
-			delete(t.activeCallByNode, c.id)
-			t.sendNextCall(c.id)
+			if inQueue {
+				// Queued call cancelled before being sent: drop just this call.
+				t.callQueue[c.id] = slices.Delete(t.callQueue[c.id], qi, qi+1)
+				if len(t.callQueue[c.id]) == 0 {
+					delete(t.callQueue, c.id)
+				}
+			} else {
+				// Active call finished: tear it down and start the next queued call.
+				c.timeout.Stop()
+				delete(t.activeCallByAuth, c.nonce)
+				delete(t.activeCallByNode, c.id)
+				t.sendNextCall(c.id)
+			}
 
 		case r := <-t.sendCh:
 			t.send(r.destID, r.destAddr, r.msg, nil)


### PR DESCRIPTION
Companion to #58.

## Problem
Dispatch keeps at most one active call per node ID; a second call to the same node waits in `callQueue`. The `callDoneCh` handler asserted every `callDone` was for the *active* call and panicked otherwise (`BUG: callDone for inactive call`).

#58 added `<-quit` early-returns to `topicQuery`/`regtopic`, which `defer callDone(c)`. So when a TOPICQUERY/REGTOPIC call is still **queued** (behind another active call to the same node) and the iterator/registration is closed, `quit` fires → the function returns → the deferred `callDone` runs on a call that was never sent → dispatch panics. Dispatch is still running (per-operation close, not transport shutdown), so this is reachable in normal operation. It is latent on `topdisc` today: #58's quit-cases are merged but not this companion handling.

## Fix
When `callDone` arrives for a non-active call, remove it from `callQueue` (it was never sent) and continue. Only panic if not found in queue either.
