### PR TITLE
p2p/discover/topicindex: enforce waiting-time lower bound

### DIFF
--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -34,10 +34,17 @@ import (
 const (
 	occupancyExp = 10
 
-	// waitTimeG is the paper's §6 safety floor: a positive baseline in the wait
-	// modifiers so a fresh registrant still owes a seconds-order wait, not ~0
-	// (~4.5s empty-table at the default 15-min AdLifetime).
-	waitTimeG = 0.05
+	// waitBaseModifier scales the occupancy-driven base wait (paper's E factor,
+	// tuned down 10x for the testbed).
+	waitBaseModifier = 0.1
+
+	// waitTimeFloor is the paper's §6 safety floor G, expressed as a real
+	// duration: the minimum wait a fresh registrant owes at an empty table (both
+	// modifiers ~0). G is derived from it as waitTimeFloor / (waitBaseModifier *
+	// AdLifetime) so the floor is this duration regardless of AdLifetime. Set
+	// above topicTableWaitTimeFloor (the 1s admission slack) so it actually
+	// applies; ~1s effective wait after that slack. Scales up with occupancy.
+	waitTimeFloor = 2 * time.Second
 )
 
 // If a node has less than this time to wait, they will be accepted anyway.
@@ -235,8 +242,7 @@ func (tab *TopicTable) WaitTime(n *enode.Node, t TopicID) time.Duration {
 	// baseTime is the required wait-time, purely based on occupancy. When occupancy is
 	// near 1.0 (i.e. the table is empty), baseTime is AdLifetime/10. As the table gets
 	// fuller, baseTime goes up and will eventually exceed AdLifetime.
-	baseModifier := 0.1
-	baseTime := baseModifier * tab.config.AdLifetime.Seconds() / math.Pow(occupancy, occupancyExp)
+	baseTime := waitBaseModifier * tab.config.AdLifetime.Seconds() / math.Pow(occupancy, occupancyExp)
 
 	// topicMod changes the waiting time based on the ratio of registrations in the
 	// requested topic vs. all topics.
@@ -245,7 +251,10 @@ func (tab *TopicTable) WaitTime(n *enode.Node, t TopicID) time.Duration {
 	// ipMod changes the waiting time based on IP address diversity.
 	ipMod := tab.wt.ipModifier(n)
 
-	neededTime := baseTime * (topicMod + ipMod + waitTimeG)
+	// g is the §6 safety floor, derived so the empty-table floor equals
+	// waitTimeFloor independent of AdLifetime (AdLifetime cancels baseTime).
+	g := waitTimeFloor.Seconds() / (waitBaseModifier * tab.config.AdLifetime.Seconds())
+	neededTime := baseTime * (topicMod + ipMod + g)
 	computed := time.Duration(math.Ceil(neededTime * float64(time.Second)))
 
 	// Apply the §6 anti-gaming lower bound: a re-quote can't drop below the

--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -33,6 +33,11 @@ import (
 // wait time computation constants.
 const (
 	occupancyExp = 10
+
+	// waitTimeG is the paper's §6 safety floor: a positive baseline in the wait
+	// modifiers so a fresh registrant still owes a seconds-order wait, not ~0
+	// (~4.5s empty-table at the default 15-min AdLifetime).
+	waitTimeG = 0.05
 )
 
 // If a node has less than this time to wait, they will be accepted anyway.
@@ -240,15 +245,12 @@ func (tab *TopicTable) WaitTime(n *enode.Node, t TopicID) time.Duration {
 	// ipMod changes the waiting time based on IP address diversity.
 	ipMod := tab.wt.ipModifier(n)
 
-	neededTime := baseTime * math.Max(topicMod+ipMod, 0.000001)
+	neededTime := baseTime * (topicMod + ipMod + waitTimeG)
 	computed := time.Duration(math.Ceil(neededTime * float64(time.Second)))
 
-	// Enforce the paper's §6 anti-gaming lower bound: a wait time quoted at t2
-	// must not be smaller than the wait quoted at t1 by more than the elapsed
-	// time, i.e. w(t2) >= w(t1) - (t2 - t1). This stops an incumbent from
-	// resetting its accumulated wait to ~0 by re-requesting through a brief
-	// occupancy dip, which is what lets it permanently hold the registrars
-	// closest to a topic.
+	// Apply the §6 anti-gaming lower bound: a re-quote can't drop below the
+	// prior quote by more than the elapsed time, so an incumbent can't reset its
+	// accumulated wait through a brief occupancy dip.
 	return tab.wt.lowerBound(n, t, computed, tab.config.Clock.Now())
 }
 
@@ -291,11 +293,9 @@ type waitTimeState struct {
 	ipv4 *ipTree
 	ipv6 *ipTree
 
-	// Lower-bound anti-gaming state (paper §6 / spec §2.1.5). Each map holds, per
-	// active registrant key, the last wait time quoted and the clock time it was
-	// quoted at. idBounds is keyed by (topic, advertiser id); ipBounds by (topic,
-	// IP) so that an attacker cannot evade the bound by rotating advertiser IDs
-	// from the same address.
+	// Lower-bound anti-gaming state (§6 / spec §2.1.5): per active registrant, the
+	// last wait quoted and when. idBounds keys by (topic, id); ipBounds by
+	// (topic, IP prefix) so ID rotation from one address can't evade it.
 	idBounds map[idBoundKey]waitBound
 	ipBounds map[ipBoundKey]waitBound
 }
@@ -339,11 +339,9 @@ func newWaitTimeState() waitTimeState {
 	}
 }
 
-// lowerBound enforces the paper's §6 retry-protection invariant on a freshly
-// computed wait time. It raises 'computed' to the highest still-active lower
-// bound recorded for n's (topic, id) and (topic, IP) keys, then records the
-// result as the new bound at 'now' so a later re-quote cannot drop faster than
-// real elapsed time.
+// lowerBound raises 'computed' to the highest still-active bound for n's
+// (topic, id) and (topic, IP) keys, then records the result as the new bound so
+// a later re-quote can't drop faster than real elapsed time.
 func (wt *waitTimeState) lowerBound(n *enode.Node, t TopicID, computed time.Duration, now mclock.AbsTime) time.Duration {
 	result := computed
 
@@ -372,19 +370,17 @@ func (wt *waitTimeState) lowerBound(n *enode.Node, t TopicID, computed time.Dura
 	return result
 }
 
-// Prefix lengths at which the per-IP lower bound aggregates addresses, so it
-// can't be evaded by rotating addresses within one allocation. IPv4 uses /24
-// (matching regBucketSubnet); IPv6 uses /64, the smallest real subnet boundary,
-// per docs/disc-ng-ipv6-policy.md §3.2 (#53). Transition-address re-routing
-// (6to4/Teredo/NAT64) is deferred to the full policy in #54.
+// The per-IP bound aggregates by prefix so it can't be evaded by rotating
+// addresses within one allocation: /24 for v4 (matching regBucketSubnet), /64
+// for v6 per docs/disc-ng-ipv6-policy.md §3.2 (#53). Transition-address
+// re-routing is deferred to #54.
 const (
 	waitBoundPrefix4 = 24
 	waitBoundPrefix6 = 64
 )
 
-// ipBoundKeys returns the per-IP lower-bound keys for node n under topic t. A
-// dual-stack node contributes both its v4 and v6 key, each aggregated to its
-// family's prefix. LAN addresses are skipped, matching ipModifier.
+// ipBoundKeys returns the per-IP lower-bound keys for n, one per address family,
+// each aggregated to its prefix.
 func (wt *waitTimeState) ipBoundKeys(t TopicID, n *enode.Node) []ipBoundKey {
 	var (
 		ip4  enr.IPv4

--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -154,6 +154,10 @@ func (tab *TopicTable) Expire() {
 		tab.wt.removeReg(reg)
 		e = next
 	}
+	// Drop lower-bound tuples that have fully decayed. They only matter while a
+	// registrant is actively waiting, so this keeps the maps from growing
+	// unboundedly with churn.
+	tab.wt.expireBounds(now)
 }
 
 // isRegistered reports whether n is currently registered for topic t.
@@ -236,7 +240,15 @@ func (tab *TopicTable) WaitTime(n *enode.Node, t TopicID) time.Duration {
 	ipMod := tab.wt.ipModifier(n)
 
 	neededTime := baseTime * math.Max(topicMod+ipMod, 0.000001)
-	return time.Duration(math.Ceil(neededTime * float64(time.Second)))
+	computed := time.Duration(math.Ceil(neededTime * float64(time.Second)))
+
+	// Enforce the paper's §6 anti-gaming lower bound: a wait time quoted at t2
+	// must not be smaller than the wait quoted at t1 by more than the elapsed
+	// time, i.e. w(t2) >= w(t1) - (t2 - t1). This stops an incumbent from
+	// resetting its accumulated wait to ~0 by re-requesting through a brief
+	// occupancy dip, which is what lets it permanently hold the registrars
+	// closest to a topic.
+	return tab.wt.lowerBound(n, t, computed, tab.config.Clock.Now())
 }
 
 // Register adds node n for topic t if it has waited long enough.
@@ -277,12 +289,119 @@ func (tab *TopicTable) Register(n *enode.Node, t TopicID, waitTime time.Duration
 type waitTimeState struct {
 	ipv4 *ipTree
 	ipv6 *ipTree
+
+	// Lower-bound anti-gaming state (paper §6 / spec §2.1.5). Each map holds, per
+	// active registrant key, the last wait time quoted and the clock time it was
+	// quoted at. idBounds is keyed by (topic, advertiser id); ipBounds by (topic,
+	// IP) so that an attacker cannot evade the bound by rotating advertiser IDs
+	// from the same address.
+	idBounds map[idBoundKey]waitBound
+	ipBounds map[ipBoundKey]waitBound
+}
+
+// idBoundKey keys the per-(topic, advertiser id) lower bound.
+type idBoundKey struct {
+	topic TopicID
+	id    enode.ID
+}
+
+// ipBoundKey keys the per-(topic, IP) lower bound. The IP is stored in its
+// canonical string form so v4 and v6 addresses share one map.
+type ipBoundKey struct {
+	topic TopicID
+	ip    string
+}
+
+// waitBound is a (value, timestamp) lower-bound tuple.
+type waitBound struct {
+	value time.Duration
+	time  mclock.AbsTime
+}
+
+// floor returns the lower bound on the wait time at 'now', decayed by the real
+// time elapsed since the bound was recorded: bound - (now - timestamp).
+func (b waitBound) floor(now mclock.AbsTime) time.Duration {
+	return b.value - time.Duration(now.Sub(b.time))
+}
+
+// expired reports whether the bound has fully decayed and can be dropped.
+func (b waitBound) expired(now mclock.AbsTime) bool {
+	return b.floor(now) <= 0
 }
 
 func newWaitTimeState() waitTimeState {
 	return waitTimeState{
-		ipv4: newIPTree(32),
-		ipv6: newIPTree(128),
+		ipv4:     newIPTree(32),
+		ipv6:     newIPTree(128),
+		idBounds: make(map[idBoundKey]waitBound),
+		ipBounds: make(map[ipBoundKey]waitBound),
+	}
+}
+
+// lowerBound enforces the paper's §6 retry-protection invariant on a freshly
+// computed wait time. It raises 'computed' to the highest still-active lower
+// bound recorded for n's (topic, id) and (topic, IP) keys, then records the
+// result as the new bound at 'now' so a later re-quote cannot drop faster than
+// real elapsed time.
+func (wt *waitTimeState) lowerBound(n *enode.Node, t TopicID, computed time.Duration, now mclock.AbsTime) time.Duration {
+	result := computed
+
+	idKey := idBoundKey{topic: t, id: n.ID()}
+	if b, ok := wt.idBounds[idKey]; ok {
+		if f := b.floor(now); f > result {
+			result = f
+		}
+	}
+
+	ipKeys := wt.ipBoundKeys(t, n)
+	for _, k := range ipKeys {
+		if b, ok := wt.ipBounds[k]; ok {
+			if f := b.floor(now); f > result {
+				result = f
+			}
+		}
+	}
+
+	// Record the (possibly raised) result as the new bound.
+	nb := waitBound{value: result, time: now}
+	wt.idBounds[idKey] = nb
+	for _, k := range ipKeys {
+		wt.ipBounds[k] = nb
+	}
+	return result
+}
+
+// ipBoundKeys returns the per-IP lower-bound keys for node n under topic t. A
+// dual-stack node contributes both its v4 and v6 key. LAN addresses are skipped,
+// matching ipModifier. The longest-prefix aggregation hinted at by the spec is
+// approximated here by the full address; an explicit IPv6 prefix policy is
+// tracked separately (see compliance doc §3.2 / Issue #54).
+func (wt *waitTimeState) ipBoundKeys(t TopicID, n *enode.Node) []ipBoundKey {
+	var (
+		ip4  enr.IPv4
+		ip6  enr.IPv6
+		keys []ipBoundKey
+	)
+	if n.Load(&ip4) == nil && !netutil.IsLAN(net.IP(ip4)) {
+		keys = append(keys, ipBoundKey{topic: t, ip: net.IP(ip4).String()})
+	}
+	if n.Load(&ip6) == nil && !netutil.IsLAN(net.IP(ip6)) {
+		keys = append(keys, ipBoundKey{topic: t, ip: net.IP(ip6).String()})
+	}
+	return keys
+}
+
+// expireBounds drops lower-bound tuples that have fully decayed at 'now'.
+func (wt *waitTimeState) expireBounds(now mclock.AbsTime) {
+	for k, b := range wt.idBounds {
+		if b.expired(now) {
+			delete(wt.idBounds, k)
+		}
+	}
+	for k, b := range wt.ipBounds {
+		if b.expired(now) {
+			delete(wt.ipBounds, k)
+		}
 	}
 }
 

--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -305,8 +306,8 @@ type idBoundKey struct {
 	id    enode.ID
 }
 
-// ipBoundKey keys the per-(topic, IP) lower bound. The IP is stored in its
-// canonical string form so v4 and v6 addresses share one map.
+// ipBoundKey keys the per-(topic, IP-prefix) lower bound. The prefix is stored
+// in its canonical string form so v4 and v6 addresses share one map.
 type ipBoundKey struct {
 	topic TopicID
 	ip    string
@@ -371,24 +372,58 @@ func (wt *waitTimeState) lowerBound(n *enode.Node, t TopicID, computed time.Dura
 	return result
 }
 
+// Prefix lengths at which the per-IP lower bound aggregates addresses, so it
+// can't be evaded by rotating addresses within one allocation. IPv4 uses /24
+// (matching regBucketSubnet); IPv6 uses /64, the smallest real subnet boundary,
+// per docs/disc-ng-ipv6-policy.md §3.2 (#53). Transition-address re-routing
+// (6to4/Teredo/NAT64) is deferred to the full policy in #54.
+const (
+	waitBoundPrefix4 = 24
+	waitBoundPrefix6 = 64
+)
+
 // ipBoundKeys returns the per-IP lower-bound keys for node n under topic t. A
-// dual-stack node contributes both its v4 and v6 key. LAN addresses are skipped,
-// matching ipModifier. The longest-prefix aggregation hinted at by the spec is
-// approximated here by the full address; an explicit IPv6 prefix policy is
-// tracked separately (see compliance doc §3.2 / Issue #54).
+// dual-stack node contributes both its v4 and v6 key, each aggregated to its
+// family's prefix. LAN addresses are skipped, matching ipModifier.
 func (wt *waitTimeState) ipBoundKeys(t TopicID, n *enode.Node) []ipBoundKey {
 	var (
 		ip4  enr.IPv4
 		ip6  enr.IPv6
 		keys []ipBoundKey
 	)
-	if n.Load(&ip4) == nil && !netutil.IsLAN(net.IP(ip4)) {
-		keys = append(keys, ipBoundKey{topic: t, ip: net.IP(ip4).String()})
+	if n.Load(&ip4) == nil {
+		if k, ok := ipBoundKeyFor(t, net.IP(ip4)); ok {
+			keys = append(keys, k)
+		}
 	}
-	if n.Load(&ip6) == nil && !netutil.IsLAN(net.IP(ip6)) {
-		keys = append(keys, ipBoundKey{topic: t, ip: net.IP(ip6).String()})
+	if n.Load(&ip6) == nil {
+		if k, ok := ipBoundKeyFor(t, net.IP(ip6)); ok {
+			keys = append(keys, k)
+		}
 	}
 	return keys
+}
+
+// ipBoundKeyFor builds the bound key for ip, aggregated to its family's prefix
+// (/24 for v4, /64 for v6). It reports ok=false for LAN or malformed addresses.
+func ipBoundKeyFor(t TopicID, ip net.IP) (ipBoundKey, bool) {
+	if ip == nil || netutil.IsLAN(ip) {
+		return ipBoundKey{}, false
+	}
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return ipBoundKey{}, false
+	}
+	addr = addr.Unmap()
+	bits := waitBoundPrefix6
+	if addr.Is4() {
+		bits = waitBoundPrefix4
+	}
+	prefix, err := addr.Prefix(bits)
+	if err != nil {
+		return ipBoundKey{}, false
+	}
+	return ipBoundKey{topic: t, ip: prefix.String()}, true
 }
 
 // expireBounds drops lower-bound tuples that have fully decayed at 'now'.

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -20,9 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	mrand "math/rand"
+	"net"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/internal/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -97,6 +100,79 @@ func TestTopicTableRandomNodes(t *testing.T) {
 	t.Run(fmt.Sprint(N), func(t *testing.T) { check(t, N, N) })
 	t.Run(fmt.Sprint(N-1), func(t *testing.T) { check(t, N-1, N-1) })
 	t.Run(fmt.Sprint(N+1), func(t *testing.T) { check(t, N+1, N) })
+}
+
+// TestTopicTableWaitTimeLowerBound verifies the paper §6 / spec §2.1.5
+// anti-gaming lower bound: once a wait time has been quoted to a registrant, a
+// later re-quote for the same (topic, id) cannot drop faster than real elapsed
+// time, i.e. w(t2) >= w(t1) - (t2 - t1). Without the lower bound, a registrant
+// that re-requests through a momentary occupancy dip is re-quoted the (much
+// lower) instantaneous wait, which is exactly the incumbent lock-in the bound
+// is meant to prevent.
+func TestTopicTableWaitTimeLowerBound(t *testing.T) {
+	clock := new(mclock.Simulated)
+	cfg := Config{
+		AdCacheSize: 100,
+		AdLifetime:  30 * time.Second,
+		Clock:       clock,
+		Log:         testlog.Logger(t, log.LvlTrace),
+	}
+	tab := NewTopicTable(cfg)
+
+	// Load the table with same-topic registrations so the computed wait for an
+	// outsider is large (high occupancy + topic-similarity modifier).
+	const fillers = 50
+	for i := 0; i < fillers; i++ {
+		n := nodeAtDistance(enode.ID(topic1), 200, intIP(i+1))
+		if !tab.Add(n, topic1) {
+			t.Fatalf("can't add filler node %d", i)
+		}
+	}
+
+	// Quote an outsider. This records the lower bound for (topic1, n.ID()).
+	n := nodeAtDistance(enode.ID(topic1), 100, net.IP{203, 0, 113, 1})
+	w1 := tab.WaitTime(n, topic1)
+	if w1 <= cfg.AdLifetime {
+		t.Fatalf("test setup: expected a large initial wait, got %v", w1)
+	}
+	t.Log("initial wait", w1)
+
+	// Advance to the filler lifetime and expire them. The table is now empty, so
+	// the *instantaneous* computed wait collapses toward zero — this is the
+	// occupancy dip an incumbent would exploit to reset its accumulated wait.
+	clock.Run(cfg.AdLifetime)
+	tab.Expire()
+	if tab.all.Len() != 0 {
+		t.Fatalf("expected empty table after expiry, got %d entries", tab.all.Len())
+	}
+
+	// A genuinely fresh outsider now gets a near-zero wait (nothing to lower-bound).
+	fresh := nodeAtDistance(enode.ID(topic1), 100, net.IP{203, 0, 113, 2})
+	if wf := tab.WaitTime(fresh, topic1); wf > time.Second {
+		t.Fatalf("fresh node should see a tiny wait on an empty table, got %v", wf)
+	}
+
+	// The previously-quoted node must NOT be reset to that tiny wait. Its quote
+	// may only have decayed by the elapsed time (AdLifetime).
+	w2 := tab.WaitTime(n, topic1)
+	t.Log("re-quoted wait after dip", w2)
+	if lb := w1 - cfg.AdLifetime; w2 < lb {
+		t.Fatalf("lower bound violated: w2=%v < w1-elapsed=%v", w2, lb)
+	}
+	if w2 <= time.Second {
+		t.Fatalf("incumbent reset to a tiny wait through the occupancy dip: %v", w2)
+	}
+
+	// Decay to completion: once timestamp+value has passed, the bound is dropped
+	// and the node is quoted the (now tiny) instantaneous wait again.
+	clock.Run(w2 + time.Second)
+	tab.Expire()
+	if got := len(tab.wt.idBounds) + len(tab.wt.ipBounds); got != 0 {
+		t.Fatalf("expected all lower-bound tuples expired, got %d", got)
+	}
+	if w3 := tab.WaitTime(n, topic1); w3 > time.Second {
+		t.Fatalf("expected tiny wait after the bound fully decayed, got %v", w3)
+	}
 }
 
 func testConfig(t *testing.T) Config {

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -146,34 +146,34 @@ func TestTopicTableWaitTimeLowerBound(t *testing.T) {
 		t.Fatalf("expected empty table after expiry, got %d entries", tab.all.Len())
 	}
 
-	// A genuinely fresh outsider now gets a near-zero wait (nothing to
+	// A genuinely fresh outsider now gets only the small G floor (nothing to
 	// lower-bound). It must be in a different /24 than n, since the bound
 	// aggregates per /24.
 	fresh := nodeAtDistance(enode.ID(topic1), 100, net.IP{198, 51, 100, 2})
-	if wf := tab.WaitTime(fresh, topic1); wf > time.Second {
-		t.Fatalf("fresh node should see a tiny wait on an empty table, got %v", wf)
+	if wf := tab.WaitTime(fresh, topic1); wf > 5*time.Second {
+		t.Fatalf("fresh node should see only the small floor on an empty table, got %v", wf)
 	}
 
-	// The previously-quoted node must NOT be reset to that tiny wait. Its quote
-	// may only have decayed by the elapsed time (AdLifetime).
+	// The previously-quoted node must NOT be reset to the floor. Its quote may
+	// only have decayed by the elapsed time (AdLifetime).
 	w2 := tab.WaitTime(n, topic1)
 	t.Log("re-quoted wait after dip", w2)
 	if lb := w1 - cfg.AdLifetime; w2 < lb {
 		t.Fatalf("lower bound violated: w2=%v < w1-elapsed=%v", w2, lb)
 	}
-	if w2 <= time.Second {
-		t.Fatalf("incumbent reset to a tiny wait through the occupancy dip: %v", w2)
+	if w2 <= 5*time.Second {
+		t.Fatalf("incumbent reset to the floor through the occupancy dip: %v", w2)
 	}
 
 	// Decay to completion: once timestamp+value has passed, the bound is dropped
-	// and the node is quoted the (now tiny) instantaneous wait again.
+	// and the node is quoted only the small floor again.
 	clock.Run(w2 + time.Second)
 	tab.Expire()
 	if got := len(tab.wt.idBounds) + len(tab.wt.ipBounds); got != 0 {
 		t.Fatalf("expected all lower-bound tuples expired, got %d", got)
 	}
-	if w3 := tab.WaitTime(n, topic1); w3 > time.Second {
-		t.Fatalf("expected tiny wait after the bound fully decayed, got %v", w3)
+	if w3 := tab.WaitTime(n, topic1); w3 > 5*time.Second {
+		t.Fatalf("expected only the small floor after the bound fully decayed, got %v", w3)
 	}
 }
 
@@ -209,11 +209,11 @@ func TestTopicTableWaitTimeBoundPrefix(t *testing.T) {
 			tab.Expire()
 
 			// A node in the same prefix inherits the still-active bound.
-			if w := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, samePrefix), topic1); w <= time.Second {
+			if w := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, samePrefix), topic1); w <= 5*time.Second {
 				t.Errorf("same-prefix node was not bounded: got %v", w)
 			}
-			// A node in a different prefix is unaffected.
-			if w := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, otherPrefix), topic1); w > time.Second {
+			// A node in a different prefix is unaffected (only the small floor).
+			if w := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, otherPrefix), topic1); w > 5*time.Second {
 				t.Errorf("different-prefix node was bounded: got %v", w)
 			}
 		})
@@ -226,22 +226,30 @@ func TestTopicTableWaitTimeBoundPrefix(t *testing.T) {
 }
 
 // TestTopicTableWaitTimeFloor checks the paper §6 safety floor G: a fresh
-// registrant on an empty table (both modifiers ~0) still owes a seconds-order
-// wait, above the admission slack, instead of the ~0 the modifiers alone give.
+// registrant on an empty table (both modifiers ~0) owes ~waitTimeFloor, above
+// the admission slack, and — since G is derived as waitTimeFloor/(baseMod*
+// AdLifetime) — the floor is that duration independent of AdLifetime.
 func TestTopicTableWaitTimeFloor(t *testing.T) {
-	cfg := Config{
-		AdCacheSize: 100,
-		AdLifetime:  15 * time.Minute,
-		Clock:       new(mclock.Simulated),
-		Log:         testlog.Logger(t, log.LvlTrace),
-	}
-	tab := NewTopicTable(cfg)
+	for _, adLifetime := range []time.Duration{15 * time.Minute, time.Hour, 30 * time.Second} {
+		cfg := Config{
+			AdCacheSize: 100,
+			AdLifetime:  adLifetime,
+			Clock:       new(mclock.Simulated),
+			Log:         testlog.Logger(t, log.LvlTrace),
+		}
+		tab := NewTopicTable(cfg)
 
-	n := nodeAtDistance(enode.ID(topic1), 100, net.IP{203, 0, 113, 1})
-	w := tab.WaitTime(n, topic1)
-	t.Log("floor wait", w)
-	if w <= topicTableWaitTimeFloor {
-		t.Fatalf("fresh registrant wait %v does not exceed the admission slack %v", w, topicTableWaitTimeFloor)
+		n := nodeAtDistance(enode.ID(topic1), 100, net.IP{203, 0, 113, 1})
+		w := tab.WaitTime(n, topic1)
+		t.Logf("adLifetime=%v floor wait=%v", adLifetime, w)
+		if w <= topicTableWaitTimeFloor {
+			t.Fatalf("adLifetime=%v: fresh registrant wait %v does not exceed the admission slack %v",
+				adLifetime, w, topicTableWaitTimeFloor)
+		}
+		// AdLifetime-independent: the empty-table floor is ~waitTimeFloor.
+		if w < waitTimeFloor || w > waitTimeFloor+time.Second {
+			t.Fatalf("adLifetime=%v: floor %v not ~waitTimeFloor %v", adLifetime, w, waitTimeFloor)
+		}
 	}
 }
 

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -225,6 +225,26 @@ func TestTopicTableWaitTimeBoundPrefix(t *testing.T) {
 		net.ParseIP("2001:db8:1:1::1"), net.ParseIP("2001:db8:1:1::9"), net.ParseIP("2001:db8:2:2::9"))
 }
 
+// TestTopicTableWaitTimeFloor checks the paper §6 safety floor G: a fresh
+// registrant on an empty table (both modifiers ~0) still owes a seconds-order
+// wait, above the admission slack, instead of the ~0 the modifiers alone give.
+func TestTopicTableWaitTimeFloor(t *testing.T) {
+	cfg := Config{
+		AdCacheSize: 100,
+		AdLifetime:  15 * time.Minute,
+		Clock:       new(mclock.Simulated),
+		Log:         testlog.Logger(t, log.LvlTrace),
+	}
+	tab := NewTopicTable(cfg)
+
+	n := nodeAtDistance(enode.ID(topic1), 100, net.IP{203, 0, 113, 1})
+	w := tab.WaitTime(n, topic1)
+	t.Log("floor wait", w)
+	if w <= topicTableWaitTimeFloor {
+		t.Fatalf("fresh registrant wait %v does not exceed the admission slack %v", w, topicTableWaitTimeFloor)
+	}
+}
+
 func testConfig(t *testing.T) Config {
 	return Config{
 		AdCacheSize: 20,

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -146,8 +146,10 @@ func TestTopicTableWaitTimeLowerBound(t *testing.T) {
 		t.Fatalf("expected empty table after expiry, got %d entries", tab.all.Len())
 	}
 
-	// A genuinely fresh outsider now gets a near-zero wait (nothing to lower-bound).
-	fresh := nodeAtDistance(enode.ID(topic1), 100, net.IP{203, 0, 113, 2})
+	// A genuinely fresh outsider now gets a near-zero wait (nothing to
+	// lower-bound). It must be in a different /24 than n, since the bound
+	// aggregates per /24.
+	fresh := nodeAtDistance(enode.ID(topic1), 100, net.IP{198, 51, 100, 2})
 	if wf := tab.WaitTime(fresh, topic1); wf > time.Second {
 		t.Fatalf("fresh node should see a tiny wait on an empty table, got %v", wf)
 	}
@@ -173,6 +175,54 @@ func TestTopicTableWaitTimeLowerBound(t *testing.T) {
 	if w3 := tab.WaitTime(n, topic1); w3 > time.Second {
 		t.Fatalf("expected tiny wait after the bound fully decayed, got %v", w3)
 	}
+}
+
+// TestTopicTableWaitTimeBoundPrefix verifies that the per-IP lower bound
+// aggregates by prefix — /24 for IPv4, /64 for IPv6 — so it can't be evaded by
+// rotating addresses within one allocation, while a different prefix stays
+// independent. Each node gets a distinct random id, so the only thing that can
+// carry the bound from one node to another is a shared IP prefix.
+func TestTopicTableWaitTimeBoundPrefix(t *testing.T) {
+	check := func(name string, first, samePrefix, otherPrefix net.IP) {
+		t.Run(name, func(t *testing.T) {
+			clock := new(mclock.Simulated)
+			cfg := Config{
+				AdCacheSize: 100,
+				AdLifetime:  30 * time.Second,
+				Clock:       clock,
+				Log:         testlog.Logger(t, log.LvlTrace),
+			}
+			tab := NewTopicTable(cfg)
+			for i := 0; i < 50; i++ {
+				if !tab.Add(nodeAtDistance(enode.ID(topic1), 200, intIP(i+1)), topic1) {
+					t.Fatalf("can't add filler %d", i)
+				}
+			}
+
+			// Quote `first` to record a bound for its prefix, then drain the table
+			// so the instantaneous computed wait collapses to ~0.
+			w1 := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, first), topic1)
+			if w1 <= cfg.AdLifetime {
+				t.Fatalf("setup: expected a large initial wait, got %v", w1)
+			}
+			clock.Run(cfg.AdLifetime)
+			tab.Expire()
+
+			// A node in the same prefix inherits the still-active bound.
+			if w := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, samePrefix), topic1); w <= time.Second {
+				t.Errorf("same-prefix node was not bounded: got %v", w)
+			}
+			// A node in a different prefix is unaffected.
+			if w := tab.WaitTime(nodeAtDistance(enode.ID(topic1), 100, otherPrefix), topic1); w > time.Second {
+				t.Errorf("different-prefix node was bounded: got %v", w)
+			}
+		})
+	}
+
+	check("ipv4",
+		net.IP{203, 0, 113, 1}, net.IP{203, 0, 113, 9}, net.IP{198, 51, 100, 9})
+	check("ipv6",
+		net.ParseIP("2001:db8:1:1::1"), net.ParseIP("2001:db8:1:1::9"), net.ParseIP("2001:db8:2:2::9"))
 }
 
 func testConfig(t *testing.T) Config {


### PR DESCRIPTION
Implements the TopDisc **waiting-time lower bound** (paper §6 / compliance §2.1.5). Closes #80.

## Invariant

Once a registrant is quoted a wait `w(t1)`, a later quote must satisfy `w(t2) >= w(t1) - (t2 - t1)` — a re-quote can only decay at real-time rate, never reset lower.

`TopicTable.WaitTime` was memoryless, so an incumbent could let its ad expire and re-register through the brief occupancy dip at a near-zero re-quote, permanently holding the registrars closest to a topic. With the bound, accumulated wait persists, the slot becomes contestable, and the close set rotates.

## Changes (`topictable.go`)

- `waitTimeState` keeps per-`(topic, id)` and per-`(topic, IP-prefix)` lower-bound tuples `(value, timestamp)`; `WaitTime` raises the computed wait to the highest still-active decayed bound and records the new bound. `Expire` prunes fully-decayed tuples.
- **IPv6 (#53):** the per-IP bound aggregates by prefix — `/24` v4 (matching `regBucketSubnet`), `/64` v6 per `docs/disc-ng-ipv6-policy.md` §3.2 — so it can't be evaded by rotating within one allocation. Transition-address re-routing stays with #54.
- **G floor (§2.1.3):**  G is derived from a real duration — `G = waitTimeFloor / (waitBaseModifier * AdLifetime)` with `waitTimeFloor = 2s` — so the empty-table floor is **2s regardless of AdLifetime** 


