### PR TITLE
p2p/discover/topicindex: keep bucket IP tracker consistent on record update

### DIFF
--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -176,33 +176,29 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 				continue
 			}
 			oldIP, newIP := attempt.Node.IP(), n.IP()
-			if oldIP.Equal(newIP) {
+			switch {
+			case oldIP.Equal(newIP),
+				oldIP != nil && newIP != nil && netutil.SameNet(regBucketSubnet, oldIP, newIP):
+				// Same endpoint, or a move within the same /24: the node keeps its
+				// slot, so just adopt the newer record.
 				attempt.Node = n
-				continue
-			}
-			// Endpoint moved to a new subnet. The old address is now stale, so
-			// release its slot and try to seat the new one.
-			if oldIP != nil && !netutil.IsLAN(oldIP) {
-				b.ips.Remove(oldIP)
-			}
-			if newIP != nil && !netutil.IsLAN(newIP) && !b.ips.Add(newIP) {
-				// The new subnet is full. We can neither keep the stale address
-				// nor exceed the per-subnet limit, so give up on the node; a
-				// later AddNodes can re-admit it once the subnet frees up.
-				//
-				// Restore the old slot first so removeAttempt (which releases
-				// attempt.Node's IP) decrements the right subnet exactly once.
-				// This keeps the tracker correct even if the per-bucket IP limit
-				// is ever raised above 1.
-				if oldIP != nil && !netutil.IsLAN(oldIP) {
-					b.ips.Add(oldIP)
-				}
+			case newIP != nil && !netutil.IsLAN(newIP) && !b.ips.Add(newIP):
+				// Moved to a different, already-full subnet. We seat the new slot
+				// before releasing the old one, so on failure the old slot is
+				// still held and removeAttempt releases it exactly once (correct
+				// at any per-subnet limit). Give up on the node; a later AddNodes
+				// can re-admit it once the subnet frees up.
 				r.log.Debug("Dropping registration node", "id", id, "reason", "iplimit-on-record-update")
 				r.removeAttempt(attempt, "iplimit-on-record-update")
 				r.refillAttempts(b)
-				continue
+			default:
+				// New endpoint seated (or LAN/empty and untracked): only now
+				// release the now-stale old slot.
+				if oldIP != nil && !netutil.IsLAN(oldIP) {
+					b.ips.Remove(oldIP)
+				}
+				attempt.Node = n
 			}
-			attempt.Node = n
 			continue
 		}
 

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -171,33 +171,31 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 		b := &r.buckets[bi]
 		attempt, ok := b.att[id]
 		if ok {
-			// There is already an attempt scheduled with this node.
-			// Update the record if newer.
-			if attempt.Node.Seq() < n.Seq() {
-				// If the newer record moves the node to a different endpoint,
-				// keep the bucket's IP-limit tracker consistent and re-check the
-				// new endpoint. Otherwise an update could smuggle a second
-				// address from the same subnet into the bucket, defeating the
-				// per-subnet cap and leaking the old IP's slot.
-				oldIP, newIP := attempt.Node.IP(), n.IP()
-				if !oldIP.Equal(newIP) {
-					oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
-					newTracked := newIP != nil && !netutil.IsLAN(newIP)
-					if oldTracked {
-						b.ips.Remove(oldIP)
-					}
-					if newTracked && !b.ips.Add(newIP) {
-						// New endpoint doesn't fit the bucket's subnet limit.
-						// Restore the old accounting and keep the existing record.
-						if oldTracked {
-							b.ips.Add(oldIP)
-						}
-						r.log.Debug("Ignoring registration record update", "id", n.ID(), "reason", "iplimit")
-						continue
-					}
-				}
-				attempt.Node = n
+			// Already scheduled: update the record if newer.
+			if attempt.Node.Seq() >= n.Seq() {
+				continue
 			}
+			oldIP, newIP := attempt.Node.IP(), n.IP()
+			if oldIP.Equal(newIP) {
+				attempt.Node = n
+				continue
+			}
+			// Endpoint changed: move the IP-limit accounting and re-check the
+			// per-subnet cap, so an update can't smuggle a second same-subnet
+			// address into the bucket.
+			oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
+			newTracked := newIP != nil && !netutil.IsLAN(newIP)
+			if oldTracked {
+				b.ips.Remove(oldIP)
+			}
+			if newTracked && !b.ips.Add(newIP) {
+				if oldTracked {
+					b.ips.Add(oldIP)
+				}
+				r.log.Debug("Ignoring registration record update", "id", n.ID(), "reason", "iplimit")
+				continue
+			}
+			attempt.Node = n
 			continue
 		}
 

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -181,8 +181,7 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 				continue
 			}
 			// Endpoint moved: keep the bucket's IP tracker in sync so the old
-			// subnet's slot is released and the new one is counted. Without this,
-			// a legitimate IP change strands the old /24 count forever.
+			// subnet's slot is released and the new one is counted.
 			if oldIP != nil && !netutil.IsLAN(oldIP) {
 				b.ips.Remove(oldIP)
 			}

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -19,6 +19,7 @@ package topicindex
 import (
 	"container/heap"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -61,6 +62,30 @@ type regBucket struct {
 	count [nRegStates]int
 
 	ips netutil.DistinctNetSet
+}
+
+// updateIP moves the bucket's per-/24 IP accounting from old to new and reports
+// whether new is acceptable. It is the single IP-limit gate for both a fresh
+// registration (pass old = nil) and a record update:
+//
+//   - untracked endpoints (nil / LAN) are always accepted and not counted;
+//   - a new endpoint in old's /24 keeps the slot, leaving the count unchanged;
+//   - a tracked new endpoint in a full /24 is rejected, leaving the tracker
+//     unchanged (the old slot, if any, is retained);
+//   - otherwise the new slot is taken and the old one released.
+func (b *regBucket) updateIP(oldIP, newIP net.IP) bool {
+	oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
+	newTracked := newIP != nil && !netutil.IsLAN(newIP)
+	if oldTracked && newTracked && netutil.SameNet(regBucketSubnet, oldIP, newIP) {
+		return true
+	}
+	if newTracked && !b.ips.Add(newIP) {
+		return false
+	}
+	if oldTracked {
+		b.ips.Remove(oldIP)
+	}
+	return true
 }
 
 const (
@@ -175,30 +200,15 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			if attempt.Node.Seq() >= n.Seq() {
 				continue
 			}
-			oldIP, newIP := attempt.Node.IP(), n.IP()
-			oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
-			newTracked := newIP != nil && !netutil.IsLAN(newIP)
-
-			// A move within the same tracked /24 leaves the per-subnet count
-			// unchanged, so just adopt the newer record.
-			if oldTracked && newTracked && netutil.SameNet(regBucketSubnet, oldIP, newIP) {
-				attempt.Node = n
-				continue
-			}
-			// Seat the new endpoint (if tracked) before releasing the old one. If
-			// its /24 is full, give up on the node rather than exceed the limit or
-			// keep the stale address; the old slot is still held, so removeAttempt
-			// releases it exactly once (correct at any per-subnet limit). A later
-			// AddNodes can re-admit the node once the subnet frees up.
-			if newTracked && !b.ips.Add(newIP) {
+			// Keep the bucket's IP tracker consistent for the new endpoint. If its
+			// /24 is full, drop the attempt rather than exceed the limit or keep
+			// the stale address; a later AddNodes can re-admit the node once the
+			// subnet frees up.
+			if !b.updateIP(attempt.Node.IP(), n.IP()) {
 				r.log.Debug("Dropping registration node", "id", id, "reason", "iplimit-on-record-update")
 				r.removeAttempt(attempt, "iplimit-on-record-update")
 				r.refillAttempts(b)
 				continue
-			}
-			// New endpoint is now seated (or untracked); release the old /24 slot.
-			if oldTracked {
-				b.ips.Remove(oldIP)
 			}
 			attempt.Node = n
 			continue
@@ -219,8 +229,7 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			continue
 		}
 
-		ip := n.IP()
-		if ip != nil && !netutil.IsLAN(ip) && !b.ips.Add(n.IP()) {
+		if !b.updateIP(nil, n.IP()) {
 			// IP doesn't fit in bucket limit.
 			r.log.Debug("Ignoring registration node", "id", n.ID(), "reason", "iplimit")
 			continue

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -178,28 +178,29 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			oldIP, newIP := attempt.Node.IP(), n.IP()
 			oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
 			newTracked := newIP != nil && !netutil.IsLAN(newIP)
-			switch {
-			case oldTracked && newTracked && netutil.SameNet(regBucketSubnet, oldIP, newIP):
-				// Same tracked /24 (any host within it): the per-subnet count is
-				// unchanged, so just adopt the newer record.
+
+			// A move within the same tracked /24 leaves the per-subnet count
+			// unchanged, so just adopt the newer record.
+			if oldTracked && newTracked && netutil.SameNet(regBucketSubnet, oldIP, newIP) {
 				attempt.Node = n
-			case newTracked && !b.ips.Add(newIP):
-				// Moved to a different, already-full /24. We seat the new slot
-				// before releasing the old one, so on failure the old slot is
-				// still held and removeAttempt releases it exactly once (correct
-				// at any per-subnet limit). Give up on the node; a later AddNodes
-				// can re-admit it once the subnet frees up.
+				continue
+			}
+			// Seat the new endpoint (if tracked) before releasing the old one. If
+			// its /24 is full, give up on the node rather than exceed the limit or
+			// keep the stale address; the old slot is still held, so removeAttempt
+			// releases it exactly once (correct at any per-subnet limit). A later
+			// AddNodes can re-admit the node once the subnet frees up.
+			if newTracked && !b.ips.Add(newIP) {
 				r.log.Debug("Dropping registration node", "id", id, "reason", "iplimit-on-record-update")
 				r.removeAttempt(attempt, "iplimit-on-record-update")
 				r.refillAttempts(b)
-			default:
-				// New endpoint seated in a different /24, or untracked (LAN/nil):
-				// release the old /24's slot only if it was tracked.
-				if oldTracked {
-					b.ips.Remove(oldIP)
-				}
-				attempt.Node = n
+				continue
 			}
+			// New endpoint is now seated (or untracked); release the old /24 slot.
+			if oldTracked {
+				b.ips.Remove(oldIP)
+			}
+			attempt.Node = n
 			continue
 		}
 

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -180,13 +180,22 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 				attempt.Node = n
 				continue
 			}
-			// Endpoint moved: keep the bucket's IP tracker in sync so the old
-			// subnet's slot is released and the new one is counted.
+			// Endpoint moved to a new subnet. The old address is now stale, so
+			// release its slot and try to seat the new one.
 			if oldIP != nil && !netutil.IsLAN(oldIP) {
 				b.ips.Remove(oldIP)
 			}
-			if newIP != nil && !netutil.IsLAN(newIP) {
-				b.ips.Add(newIP)
+			if newIP != nil && !netutil.IsLAN(newIP) && !b.ips.Add(newIP) {
+				// The new subnet is full. We can neither keep the stale address
+				// nor exceed the per-subnet limit, so give up on the node; a
+				// later AddNodes can re-admit it once the subnet frees up. Leave
+				// attempt.Node at the old (already-released) endpoint so
+				// removeAttempt doesn't release the new subnet's slot, which
+				// belongs to a different node.
+				r.log.Debug("Dropping registration node", "id", id, "reason", "iplimit-on-record-update")
+				r.removeAttempt(attempt, "iplimit-on-record-update")
+				r.refillAttempts(b)
+				continue
 			}
 			attempt.Node = n
 			continue

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -176,14 +176,15 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 				continue
 			}
 			oldIP, newIP := attempt.Node.IP(), n.IP()
+			oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
+			newTracked := newIP != nil && !netutil.IsLAN(newIP)
 			switch {
-			case oldIP.Equal(newIP),
-				oldIP != nil && newIP != nil && netutil.SameNet(regBucketSubnet, oldIP, newIP):
-				// Same endpoint, or a move within the same /24: the node keeps its
-				// slot, so just adopt the newer record.
+			case oldTracked && newTracked && netutil.SameNet(regBucketSubnet, oldIP, newIP):
+				// Same tracked /24 (any host within it): the per-subnet count is
+				// unchanged, so just adopt the newer record.
 				attempt.Node = n
-			case newIP != nil && !netutil.IsLAN(newIP) && !b.ips.Add(newIP):
-				// Moved to a different, already-full subnet. We seat the new slot
+			case newTracked && !b.ips.Add(newIP):
+				// Moved to a different, already-full /24. We seat the new slot
 				// before releasing the old one, so on failure the old slot is
 				// still held and removeAttempt releases it exactly once (correct
 				// at any per-subnet limit). Give up on the node; a later AddNodes
@@ -192,9 +193,9 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 				r.removeAttempt(attempt, "iplimit-on-record-update")
 				r.refillAttempts(b)
 			default:
-				// New endpoint seated (or LAN/empty and untracked): only now
-				// release the now-stale old slot.
-				if oldIP != nil && !netutil.IsLAN(oldIP) {
+				// New endpoint seated in a different /24, or untracked (LAN/nil):
+				// release the old /24's slot only if it was tracked.
+				if oldTracked {
 					b.ips.Remove(oldIP)
 				}
 				attempt.Node = n

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -174,6 +174,28 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			// There is already an attempt scheduled with this node.
 			// Update the record if newer.
 			if attempt.Node.Seq() < n.Seq() {
+				// If the newer record moves the node to a different endpoint,
+				// keep the bucket's IP-limit tracker consistent and re-check the
+				// new endpoint. Otherwise an update could smuggle a second
+				// address from the same subnet into the bucket, defeating the
+				// per-subnet cap and leaking the old IP's slot.
+				oldIP, newIP := attempt.Node.IP(), n.IP()
+				if !oldIP.Equal(newIP) {
+					oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
+					newTracked := newIP != nil && !netutil.IsLAN(newIP)
+					if oldTracked {
+						b.ips.Remove(oldIP)
+					}
+					if newTracked && !b.ips.Add(newIP) {
+						// New endpoint doesn't fit the bucket's subnet limit.
+						// Restore the old accounting and keep the existing record.
+						if oldTracked {
+							b.ips.Add(oldIP)
+						}
+						r.log.Debug("Ignoring registration record update", "id", n.ID(), "reason", "iplimit")
+						continue
+					}
+				}
 				attempt.Node = n
 			}
 			continue

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -188,10 +188,15 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			if newIP != nil && !netutil.IsLAN(newIP) && !b.ips.Add(newIP) {
 				// The new subnet is full. We can neither keep the stale address
 				// nor exceed the per-subnet limit, so give up on the node; a
-				// later AddNodes can re-admit it once the subnet frees up. Leave
-				// attempt.Node at the old (already-released) endpoint so
-				// removeAttempt doesn't release the new subnet's slot, which
-				// belongs to a different node.
+				// later AddNodes can re-admit it once the subnet frees up.
+				//
+				// Restore the old slot first so removeAttempt (which releases
+				// attempt.Node's IP) decrements the right subnet exactly once.
+				// This keeps the tracker correct even if the per-bucket IP limit
+				// is ever raised above 1.
+				if oldIP != nil && !netutil.IsLAN(oldIP) {
+					b.ips.Add(oldIP)
+				}
 				r.log.Debug("Dropping registration node", "id", id, "reason", "iplimit-on-record-update")
 				r.removeAttempt(attempt, "iplimit-on-record-update")
 				r.refillAttempts(b)

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -175,17 +175,19 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			if attempt.Node.Seq() >= n.Seq() {
 				continue
 			}
-			// If the endpoint moved, keep the bucket's IP tracker in sync so the
-			// old subnet's slot is released and the new one is counted. Without
-			// this, a legitimate IP change strands the old /24 count forever.
 			oldIP, newIP := attempt.Node.IP(), n.IP()
-			if !oldIP.Equal(newIP) {
-				if oldIP != nil && !netutil.IsLAN(oldIP) {
-					b.ips.Remove(oldIP)
-				}
-				if newIP != nil && !netutil.IsLAN(newIP) {
-					b.ips.Add(newIP)
-				}
+			if oldIP.Equal(newIP) {
+				attempt.Node = n
+				continue
+			}
+			// Endpoint moved: keep the bucket's IP tracker in sync so the old
+			// subnet's slot is released and the new one is counted. Without this,
+			// a legitimate IP change strands the old /24 count forever.
+			if oldIP != nil && !netutil.IsLAN(oldIP) {
+				b.ips.Remove(oldIP)
+			}
+			if newIP != nil && !netutil.IsLAN(newIP) {
+				b.ips.Add(newIP)
 			}
 			attempt.Node = n
 			continue

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -175,25 +175,17 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			if attempt.Node.Seq() >= n.Seq() {
 				continue
 			}
+			// If the endpoint moved, keep the bucket's IP tracker in sync so the
+			// old subnet's slot is released and the new one is counted. Without
+			// this, a legitimate IP change strands the old /24 count forever.
 			oldIP, newIP := attempt.Node.IP(), n.IP()
-			if oldIP.Equal(newIP) {
-				attempt.Node = n
-				continue
-			}
-			// Endpoint changed: move the IP-limit accounting and re-check the
-			// per-subnet cap, so an update can't smuggle a second same-subnet
-			// address into the bucket.
-			oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
-			newTracked := newIP != nil && !netutil.IsLAN(newIP)
-			if oldTracked {
-				b.ips.Remove(oldIP)
-			}
-			if newTracked && !b.ips.Add(newIP) {
-				if oldTracked {
-					b.ips.Add(oldIP)
+			if !oldIP.Equal(newIP) {
+				if oldIP != nil && !netutil.IsLAN(oldIP) {
+					b.ips.Remove(oldIP)
 				}
-				r.log.Debug("Ignoring registration record update", "id", n.ID(), "reason", "iplimit")
-				continue
+				if newIP != nil && !netutil.IsLAN(newIP) {
+					b.ips.Add(newIP)
+				}
 			}
 			attempt.Node = n
 			continue

--- a/p2p/discover/topicindex/registration.go
+++ b/p2p/discover/topicindex/registration.go
@@ -65,14 +65,7 @@ type regBucket struct {
 }
 
 // updateIP moves the bucket's per-/24 IP accounting from old to new and reports
-// whether new is acceptable. It is the single IP-limit gate for both a fresh
-// registration (pass old = nil) and a record update:
-//
-//   - untracked endpoints (nil / LAN) are always accepted and not counted;
-//   - a new endpoint in old's /24 keeps the slot, leaving the count unchanged;
-//   - a tracked new endpoint in a full /24 is rejected, leaving the tracker
-//     unchanged (the old slot, if any, is retained);
-//   - otherwise the new slot is taken and the old one released.
+// whether new is acceptable. untracked ips (nil / LAN) are always accepted and not counted
 func (b *regBucket) updateIP(oldIP, newIP net.IP) bool {
 	oldTracked := oldIP != nil && !netutil.IsLAN(oldIP)
 	newTracked := newIP != nil && !netutil.IsLAN(newIP)
@@ -200,10 +193,7 @@ func (r *Registration) AddNodes(src *enode.Node, nodes []*enode.Node) {
 			if attempt.Node.Seq() >= n.Seq() {
 				continue
 			}
-			// Keep the bucket's IP tracker consistent for the new endpoint. If its
-			// /24 is full, drop the attempt rather than exceed the limit or keep
-			// the stale address; a later AddNodes can re-admit the node once the
-			// subnet frees up.
+			// Keep the bucket's IP tracker consistent if its ip changes. Drop the attempt if its going over bucket thresholds.
 			if !b.updateIP(attempt.Node.IP(), n.IP()) {
 				r.log.Debug("Dropping registration node", "id", id, "reason", "iplimit-on-record-update")
 				r.removeAttempt(attempt, "iplimit-on-record-update")
@@ -330,13 +320,7 @@ func (r *Registration) validate(att *RegAttempt) {
 func (r *Registration) HandleTicketResponse(att *RegAttempt, ticket []byte, waitTime time.Duration) {
 	r.validate(att)
 
-	// Drop the attempt when a single quote already exceeds the registrant's
-	// total budget for this (topic, registrar) pair. Waiting longer than
-	// RegAttemptTimeout on one response is strictly worse than picking
-	// another registrar — the §6 eq. 1 formula can legitimately produce
-	// values above AdLifetime under heavy contention, so AdLifetime is too
-	// aggressive a threshold here; the cumulative cap below is the real
-	// budget.
+	// Drop the attempt when a single quote already exceeds the registrant's total allowed waiting time for the registration.
 	if waitTime > r.cfg.RegAttemptTimeout {
 		r.removeAttempt(att, "wtime-above-budget")
 		return

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -436,12 +436,13 @@ func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
 		probes   []probe  // follow-up admissions checking the tracker count
 	}{
 		{
-			name:     "into-full-subnet",
+			name:     "into-empty-subnet",
 			limit:    1,
-			setup:    []net.IP{{3, 0, 2, 1}, {4, 0, 2, 1}},
-			moveIP:   net.IP{4, 0, 2, 99}, // /24-4 already full
-			wantKept: false,
-			probes:   []probe{{net.IP{4, 0, 2, 200}, false}}, // still full
+			setup:    []net.IP{{3, 0, 2, 1}},
+			moveIP:   net.IP{6, 0, 2, 1}, // different /24, has room
+			wantKept: true,
+			// Old /24-3 slot is freed (a fresh node fits); new /24-6 is now counted.
+			probes: []probe{{net.IP{3, 0, 2, 9}, true}, {net.IP{6, 0, 2, 9}, false}},
 		},
 		{
 			name:     "into-full-subnet-limit-2",
@@ -491,6 +492,12 @@ func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
 			}
 			if c.wantKept && !att.Node.IP().Equal(c.moveIP) {
 				t.Fatalf("record not updated: got IP %v, want %v", att.Node.IP(), c.moveIP)
+			}
+			// The other setup nodes are untouched by node 0's update and must remain.
+			for i := 1; i < len(nodes); i++ {
+				if _, ok := bucket.att[nodes[i].ID()]; !ok {
+					t.Fatalf("node %d (%v) should still be present", i, c.setup[i])
+				}
 			}
 
 			for _, p := range c.probes {

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -229,45 +229,6 @@ func TestRegistrationIPCheck(t *testing.T) {
 	}
 }
 
-// TestRegistrationIPCheckOnRecordUpdate checks that when an already-known node
-// presents a newer record with a different endpoint, the per-bucket IP-limit
-// tracker is kept consistent, so the update can't be used to slip a second
-// address from the same subnet into the bucket.
-func TestRegistrationIPCheckOnRecordUpdate(t *testing.T) {
-	cfg := testConfig(t)
-	r := NewRegistration(topic1, cfg)
-
-	// node1 registers with an address in subnet A.
-	node1 := nodeAtDistance(enode.ID(topic1), 200, net.IP{192, 0, 2, 1})
-	r.AddNodes(nil, []*enode.Node{node1})
-	if r.NodeCount() != 1 {
-		t.Fatalf("expected 1 node after initial add, got %d", r.NodeCount())
-	}
-
-	// node1 presents a newer record that moves it to subnet B. The tracker must
-	// release subnet A and now count subnet B.
-	node1b := nodeWithSeq(node1.ID(), net.IP{198, 51, 100, 1}, node1.Seq()+1)
-	r.AddNodes(nil, []*enode.Node{node1b})
-
-	// A different node in subnet B must now be rejected: subnet B already holds
-	// node1's slot. Before the fix the tracker still counted subnet A, so this
-	// second subnet-B node was wrongly admitted.
-	node2 := nodeAtDistance(enode.ID(topic1), 200, net.IP{198, 51, 100, 2})
-	r.AddNodes(nil, []*enode.Node{node2})
-
-	if r.NodeCount() != 1 {
-		t.Fatalf("subnet limit bypassed on record update: got %d nodes, want 1", r.NodeCount())
-	}
-
-	// Subnet A must have been released by the move: a node in subnet A is now
-	// admitted. Before the fix its slot stayed counted forever (the leak).
-	node3 := nodeAtDistance(enode.ID(topic1), 200, net.IP{192, 0, 2, 2})
-	r.AddNodes(nil, []*enode.Node{node3})
-	if r.NodeCount() != 2 {
-		t.Fatalf("old subnet not released on record update: got %d nodes, want 2", r.NodeCount())
-	}
-}
-
 // This test checks that registration attempts are created for found nodes.
 func TestRegistrationRequests(t *testing.T) {
 	cfg := testConfig(t)
@@ -481,10 +442,7 @@ func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
 			}
 
 			// Update node 0 to moveIP with a newer ENR.
-			var rec enr.Record
-			rec.Set(enr.IP(c.moveIP))
-			rec.SetSeq(nodes[0].Seq() + 1)
-			r.AddNodes(nil, []*enode.Node{enode.SignNull(&rec, nodes[0].ID())})
+			r.AddNodes(nil, []*enode.Node{nodeWithSeq(nodes[0].ID(), c.moveIP, nodes[0].Seq()+1)})
 
 			att, ok := bucket.att[nodes[0].ID()]
 			if ok != c.wantKept {

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -258,6 +258,14 @@ func TestRegistrationIPCheckOnRecordUpdate(t *testing.T) {
 	if r.NodeCount() != 1 {
 		t.Fatalf("subnet limit bypassed on record update: got %d nodes, want 1", r.NodeCount())
 	}
+
+	// Subnet A must have been released by the move: a node in subnet A is now
+	// admitted. Before the fix its slot stayed counted forever (the leak).
+	node3 := nodeAtDistance(enode.ID(topic1), 200, net.IP{192, 0, 2, 2})
+	r.AddNodes(nil, []*enode.Node{node3})
+	if r.NodeCount() != 2 {
+		t.Fatalf("old subnet not released on record update: got %d nodes, want 2", r.NodeCount())
+	}
 }
 
 // This test checks that registration attempts are created for found nodes.

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -463,3 +463,49 @@ func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
 		t.Fatal("third node in the full /24 should have been rejected")
 	}
 }
+
+// TestRegistrationRecordUpdateIPLimitAboveOne checks the record-update handling
+// stays correct when the per-bucket /24 limit is greater than 1: dropping a node
+// that moved into a full subnet must not release a co-tenant's slot in the node's
+// old subnet. (The constant is 1 today; this guards a future change.)
+func TestRegistrationRecordUpdateIPLimitAboveOne(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+	base := enode.ID(topic1)
+
+	bi := r.bucketIndex(nodeAtDistance(base, 200, net.IP{9, 0, 2, 9}).ID())
+	r.buckets[bi].ips.Limit = 2 // raise the per-bucket /24 limit
+	bucket := &r.buckets[bi]
+
+	// /24-X: a, c. /24-Y (full): d, e.
+	a := nodeAtDistance(base, 200, net.IP{3, 0, 2, 1})
+	c := nodeAtDistance(base, 200, net.IP{3, 0, 2, 2})
+	d := nodeAtDistance(base, 200, net.IP{4, 0, 2, 1})
+	e := nodeAtDistance(base, 200, net.IP{4, 0, 2, 2})
+	r.AddNodes(nil, []*enode.Node{a, c, d, e})
+	for _, n := range []*enode.Node{a, c, d, e} {
+		if _, ok := bucket.att[n.ID()]; !ok {
+			t.Fatal("setup: node not admitted")
+		}
+	}
+
+	// a moves into /24-Y (full) → a dropped, c must keep its /24-X slot.
+	var rec enr.Record
+	rec.Set(enr.IP(net.IP{4, 0, 2, 99}))
+	rec.SetSeq(a.Seq() + 1)
+	r.AddNodes(nil, []*enode.Node{enode.SignNull(&rec, a.ID())})
+	if _, ok := bucket.att[a.ID()]; ok {
+		t.Fatal("node a should have been dropped")
+	}
+
+	// /24-X now holds exactly 1 (c): exactly one more fits, a second is rejected.
+	f := nodeAtDistance(base, 200, net.IP{3, 0, 2, 3})
+	g := nodeAtDistance(base, 200, net.IP{3, 0, 2, 4})
+	r.AddNodes(nil, []*enode.Node{f, g})
+	if _, ok := bucket.att[f.ID()]; !ok {
+		t.Fatal("one more node should fit in /24-X (limit 2)")
+	}
+	if _, ok := bucket.att[g.ID()]; ok {
+		t.Fatal("second extra node exceeds /24 limit — c's slot was undercounted")
+	}
+}

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -417,3 +417,49 @@ func nodeWithSeq(id enode.ID, ip net.IP, seq uint64) *enode.Node {
 func intIP(i int) net.IP {
 	return net.IP{byte(i), 0, 2, byte(i)}
 }
+
+// TestRegistrationRecordUpdateIPLimit checks that when an already-scheduled node
+// advances its ENR to an IP in a subnet that is already full for the bucket, the
+// node is dropped rather than seated in violation of the per-/24 limit.
+func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+	base := enode.ID(topic1)
+
+	// Two nodes in the same bucket, in different /24s.
+	a := nodeAtDistance(base, 200, net.IP{3, 0, 2, 1})
+	b := nodeAtDistance(base, 200, net.IP{4, 0, 2, 1})
+	r.AddNodes(nil, []*enode.Node{a, b})
+
+	bi := r.bucketIndex(a.ID())
+	bucket := &r.buckets[bi]
+	if _, ok := bucket.att[a.ID()]; !ok {
+		t.Fatal("setup: node a not admitted")
+	}
+	if _, ok := bucket.att[b.ID()]; !ok {
+		t.Fatal("setup: node b not admitted")
+	}
+
+	// a advertises a newer ENR moving into b's (full) /24.
+	var rec enr.Record
+	rec.Set(enr.IP(net.IP{4, 0, 2, 99})) // same /24 as b, different host
+	rec.SetSeq(a.Seq() + 1)
+	aMoved := enode.SignNull(&rec, a.ID())
+	r.AddNodes(nil, []*enode.Node{aMoved})
+
+	// a must be dropped: it can neither keep its stale IP nor put a second node
+	// in b's /24.
+	if _, ok := bucket.att[a.ID()]; ok {
+		t.Fatal("node a should have been dropped after moving into a full /24")
+	}
+	if _, ok := bucket.att[b.ID()]; !ok {
+		t.Fatal("node b should still be present")
+	}
+
+	// The /24 limit must still hold: a fresh node in that /24 is rejected.
+	c := nodeAtDistance(base, 200, net.IP{4, 0, 2, 200})
+	r.AddNodes(nil, []*enode.Node{c})
+	if _, ok := bucket.att[c.ID()]; ok {
+		t.Fatal("third node in the full /24 should have been rejected")
+	}
+}

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -229,6 +229,37 @@ func TestRegistrationIPCheck(t *testing.T) {
 	}
 }
 
+// TestRegistrationIPCheckOnRecordUpdate checks that when an already-known node
+// presents a newer record with a different endpoint, the per-bucket IP-limit
+// tracker is kept consistent, so the update can't be used to slip a second
+// address from the same subnet into the bucket.
+func TestRegistrationIPCheckOnRecordUpdate(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+
+	// node1 registers with an address in subnet A.
+	node1 := nodeAtDistance(enode.ID(topic1), 200, net.IP{192, 0, 2, 1})
+	r.AddNodes(nil, []*enode.Node{node1})
+	if r.NodeCount() != 1 {
+		t.Fatalf("expected 1 node after initial add, got %d", r.NodeCount())
+	}
+
+	// node1 presents a newer record that moves it to subnet B. The tracker must
+	// release subnet A and now count subnet B.
+	node1b := nodeWithSeq(node1.ID(), net.IP{198, 51, 100, 1}, node1.Seq()+1)
+	r.AddNodes(nil, []*enode.Node{node1b})
+
+	// A different node in subnet B must now be rejected: subnet B already holds
+	// node1's slot. Before the fix the tracker still counted subnet A, so this
+	// second subnet-B node was wrongly admitted.
+	node2 := nodeAtDistance(enode.ID(topic1), 200, net.IP{198, 51, 100, 2})
+	r.AddNodes(nil, []*enode.Node{node2})
+
+	if r.NodeCount() != 1 {
+		t.Fatalf("subnet limit bypassed on record update: got %d nodes, want 1", r.NodeCount())
+	}
+}
+
 // This test checks that registration attempts are created for found nodes.
 func TestRegistrationRequests(t *testing.T) {
 	cfg := testConfig(t)
@@ -364,6 +395,15 @@ func nodeAtDistance(base enode.ID, ld int, ip net.IP) *enode.Node {
 	var r enr.Record
 	r.Set(enr.IP(ip))
 	return enode.SignNull(&r, randomID(base, ld))
+}
+
+// nodeWithSeq creates a node with an explicit ID, IP and sequence number. It is
+// used to simulate a node re-advertising itself with a newer record.
+func nodeWithSeq(id enode.ID, ip net.IP, seq uint64) *enode.Node {
+	var r enr.Record
+	r.Set(enr.IP(ip))
+	r.SetSeq(seq)
+	return enode.SignNull(&r, id)
 }
 
 func intIP(i int) net.IP {

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -379,11 +379,12 @@ func intIP(i int) net.IP {
 	return net.IP{byte(i), 0, 2, byte(i)}
 }
 
-// TestRegistrationRecordUpdateIPLimit checks that the per-/24 IP tracker stays
-// consistent when an already-scheduled node advances its ENR to a new endpoint:
-// a move within the same /24 is kept, a move into a full /24 is dropped, and a
-// dropped node never releases a co-tenant's slot (even if the limit is > 1).
-func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
+// TestRegistrationRecordUpdate checks how an already-scheduled node's newer ENR
+// is handled: a non-newer seq is ignored, and an endpoint change keeps the
+// per-/24 IP tracker consistent — a move within the same /24 is kept, a move to
+// a free /24 seats the new subnet and releases the old, a move into a full /24
+// is dropped, and a dropped node never releases a co-tenant's slot.
+func TestRegistrationRecordUpdate(t *testing.T) {
 	type probe struct {
 		ip    net.IP
 		admit bool
@@ -393,9 +394,20 @@ func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
 		limit    int
 		setup    []net.IP // admitted up front; index 0's record is updated
 		moveIP   net.IP   // index 0's new endpoint
+		sameSeq  bool     // offer the update with a non-newer seq (must be ignored)
 		wantKept bool     // whether index 0 survives the update
 		probes   []probe  // follow-up admissions checking the tracker count
 	}{
+		{
+			name:     "stale-seq-ignored",
+			limit:    1,
+			setup:    []net.IP{{3, 0, 2, 1}},
+			moveIP:   net.IP{4, 0, 2, 1}, // offered with a non-newer seq
+			sameSeq:  true,
+			wantKept: true,
+			// Update ignored: /24-3 still held (rejected), /24-4 never counted (admitted).
+			probes: []probe{{net.IP{3, 0, 2, 9}, false}, {net.IP{4, 0, 2, 9}, true}},
+		},
 		{
 			name:     "into-empty-subnet",
 			limit:    1,
@@ -441,15 +453,26 @@ func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
 				}
 			}
 
-			// Update node 0 to moveIP with a newer ENR.
-			r.AddNodes(nil, []*enode.Node{nodeWithSeq(nodes[0].ID(), c.moveIP, nodes[0].Seq()+1)})
+			// Offer node 0 a new record. A non-newer seq must be ignored.
+			seq := nodes[0].Seq() + 1
+			if c.sameSeq {
+				seq = nodes[0].Seq()
+			}
+			r.AddNodes(nil, []*enode.Node{nodeWithSeq(nodes[0].ID(), c.moveIP, seq)})
 
 			att, ok := bucket.att[nodes[0].ID()]
 			if ok != c.wantKept {
 				t.Fatalf("after update: kept=%v, want %v", ok, c.wantKept)
 			}
-			if c.wantKept && !att.Node.IP().Equal(c.moveIP) {
-				t.Fatalf("record not updated: got IP %v, want %v", att.Node.IP(), c.moveIP)
+			if c.wantKept {
+				// A stale update is ignored, so the endpoint stays as it was.
+				wantIP := c.moveIP
+				if c.sameSeq {
+					wantIP = c.setup[0]
+				}
+				if !att.Node.IP().Equal(wantIP) {
+					t.Fatalf("endpoint after update: got %v, want %v", att.Node.IP(), wantIP)
+				}
 			}
 			// The other setup nodes are untouched by node 0's update and must remain.
 			for i := 1; i < len(nodes); i++ {

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -509,3 +509,29 @@ func TestRegistrationRecordUpdateIPLimitAboveOne(t *testing.T) {
 		t.Fatal("second extra node exceeds /24 limit — c's slot was undercounted")
 	}
 }
+
+// TestRegistrationRecordUpdateSameSubnet checks that a node refreshing its ENR
+// to a different host in the same /24 is kept (not evicted), even at IP limit 1.
+func TestRegistrationRecordUpdateSameSubnet(t *testing.T) {
+	cfg := testConfig(t)
+	r := NewRegistration(topic1, cfg)
+	base := enode.ID(topic1)
+
+	a := nodeAtDistance(base, 200, net.IP{3, 0, 2, 1})
+	r.AddNodes(nil, []*enode.Node{a})
+	bi := r.bucketIndex(a.ID())
+	bucket := &r.buckets[bi]
+
+	var rec enr.Record
+	rec.Set(enr.IP(net.IP{3, 0, 2, 250})) // same /24, different host
+	rec.SetSeq(a.Seq() + 1)
+	r.AddNodes(nil, []*enode.Node{enode.SignNull(&rec, a.ID())})
+
+	att, ok := bucket.att[a.ID()]
+	if !ok {
+		t.Fatal("node moving within its own /24 should be kept")
+	}
+	if got := att.Node.IP(); !got.Equal(net.IP{3, 0, 2, 250}) {
+		t.Fatalf("record not updated: IP=%v", got)
+	}
+}

--- a/p2p/discover/topicindex/registration_test.go
+++ b/p2p/discover/topicindex/registration_test.go
@@ -418,120 +418,88 @@ func intIP(i int) net.IP {
 	return net.IP{byte(i), 0, 2, byte(i)}
 }
 
-// TestRegistrationRecordUpdateIPLimit checks that when an already-scheduled node
-// advances its ENR to an IP in a subnet that is already full for the bucket, the
-// node is dropped rather than seated in violation of the per-/24 limit.
+// TestRegistrationRecordUpdateIPLimit checks that the per-/24 IP tracker stays
+// consistent when an already-scheduled node advances its ENR to a new endpoint:
+// a move within the same /24 is kept, a move into a full /24 is dropped, and a
+// dropped node never releases a co-tenant's slot (even if the limit is > 1).
 func TestRegistrationRecordUpdateIPLimit(t *testing.T) {
-	cfg := testConfig(t)
-	r := NewRegistration(topic1, cfg)
+	type probe struct {
+		ip    net.IP
+		admit bool
+	}
+	cases := []struct {
+		name     string
+		limit    int
+		setup    []net.IP // admitted up front; index 0's record is updated
+		moveIP   net.IP   // index 0's new endpoint
+		wantKept bool     // whether index 0 survives the update
+		probes   []probe  // follow-up admissions checking the tracker count
+	}{
+		{
+			name:     "into-full-subnet",
+			limit:    1,
+			setup:    []net.IP{{3, 0, 2, 1}, {4, 0, 2, 1}},
+			moveIP:   net.IP{4, 0, 2, 99}, // /24-4 already full
+			wantKept: false,
+			probes:   []probe{{net.IP{4, 0, 2, 200}, false}}, // still full
+		},
+		{
+			name:     "into-full-subnet-limit-2",
+			limit:    2,
+			setup:    []net.IP{{3, 0, 2, 1}, {3, 0, 2, 2}, {4, 0, 2, 1}, {4, 0, 2, 2}},
+			moveIP:   net.IP{4, 0, 2, 99}, // /24-4 full (indexes 2,3)
+			wantKept: false,
+			// /24-3 must keep its co-tenant: exactly one more fits, a second does not.
+			probes: []probe{{net.IP{3, 0, 2, 3}, true}, {net.IP{3, 0, 2, 4}, false}},
+		},
+		{
+			name:     "within-same-subnet",
+			limit:    1,
+			setup:    []net.IP{{3, 0, 2, 1}},
+			moveIP:   net.IP{3, 0, 2, 250}, // same /24, different host
+			wantKept: true,
+		},
+	}
 	base := enode.ID(topic1)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := NewRegistration(topic1, testConfig(t))
+			bi := r.bucketIndex(nodeAtDistance(base, 200, net.IP{9, 0, 2, 9}).ID())
+			r.buckets[bi].ips.Limit = uint(c.limit)
+			bucket := &r.buckets[bi]
 
-	// Two nodes in the same bucket, in different /24s.
-	a := nodeAtDistance(base, 200, net.IP{3, 0, 2, 1})
-	b := nodeAtDistance(base, 200, net.IP{4, 0, 2, 1})
-	r.AddNodes(nil, []*enode.Node{a, b})
+			nodes := make([]*enode.Node, len(c.setup))
+			for i, ip := range c.setup {
+				nodes[i] = nodeAtDistance(base, 200, ip)
+			}
+			r.AddNodes(nil, nodes)
+			for i, n := range nodes {
+				if _, ok := bucket.att[n.ID()]; !ok {
+					t.Fatalf("setup: node %d (%v) not admitted", i, c.setup[i])
+				}
+			}
 
-	bi := r.bucketIndex(a.ID())
-	bucket := &r.buckets[bi]
-	if _, ok := bucket.att[a.ID()]; !ok {
-		t.Fatal("setup: node a not admitted")
-	}
-	if _, ok := bucket.att[b.ID()]; !ok {
-		t.Fatal("setup: node b not admitted")
-	}
+			// Update node 0 to moveIP with a newer ENR.
+			var rec enr.Record
+			rec.Set(enr.IP(c.moveIP))
+			rec.SetSeq(nodes[0].Seq() + 1)
+			r.AddNodes(nil, []*enode.Node{enode.SignNull(&rec, nodes[0].ID())})
 
-	// a advertises a newer ENR moving into b's (full) /24.
-	var rec enr.Record
-	rec.Set(enr.IP(net.IP{4, 0, 2, 99})) // same /24 as b, different host
-	rec.SetSeq(a.Seq() + 1)
-	aMoved := enode.SignNull(&rec, a.ID())
-	r.AddNodes(nil, []*enode.Node{aMoved})
+			att, ok := bucket.att[nodes[0].ID()]
+			if ok != c.wantKept {
+				t.Fatalf("after update: kept=%v, want %v", ok, c.wantKept)
+			}
+			if c.wantKept && !att.Node.IP().Equal(c.moveIP) {
+				t.Fatalf("record not updated: got IP %v, want %v", att.Node.IP(), c.moveIP)
+			}
 
-	// a must be dropped: it can neither keep its stale IP nor put a second node
-	// in b's /24.
-	if _, ok := bucket.att[a.ID()]; ok {
-		t.Fatal("node a should have been dropped after moving into a full /24")
-	}
-	if _, ok := bucket.att[b.ID()]; !ok {
-		t.Fatal("node b should still be present")
-	}
-
-	// The /24 limit must still hold: a fresh node in that /24 is rejected.
-	c := nodeAtDistance(base, 200, net.IP{4, 0, 2, 200})
-	r.AddNodes(nil, []*enode.Node{c})
-	if _, ok := bucket.att[c.ID()]; ok {
-		t.Fatal("third node in the full /24 should have been rejected")
-	}
-}
-
-// TestRegistrationRecordUpdateIPLimitAboveOne checks the record-update handling
-// stays correct when the per-bucket /24 limit is greater than 1: dropping a node
-// that moved into a full subnet must not release a co-tenant's slot in the node's
-// old subnet. (The constant is 1 today; this guards a future change.)
-func TestRegistrationRecordUpdateIPLimitAboveOne(t *testing.T) {
-	cfg := testConfig(t)
-	r := NewRegistration(topic1, cfg)
-	base := enode.ID(topic1)
-
-	bi := r.bucketIndex(nodeAtDistance(base, 200, net.IP{9, 0, 2, 9}).ID())
-	r.buckets[bi].ips.Limit = 2 // raise the per-bucket /24 limit
-	bucket := &r.buckets[bi]
-
-	// /24-X: a, c. /24-Y (full): d, e.
-	a := nodeAtDistance(base, 200, net.IP{3, 0, 2, 1})
-	c := nodeAtDistance(base, 200, net.IP{3, 0, 2, 2})
-	d := nodeAtDistance(base, 200, net.IP{4, 0, 2, 1})
-	e := nodeAtDistance(base, 200, net.IP{4, 0, 2, 2})
-	r.AddNodes(nil, []*enode.Node{a, c, d, e})
-	for _, n := range []*enode.Node{a, c, d, e} {
-		if _, ok := bucket.att[n.ID()]; !ok {
-			t.Fatal("setup: node not admitted")
-		}
-	}
-
-	// a moves into /24-Y (full) → a dropped, c must keep its /24-X slot.
-	var rec enr.Record
-	rec.Set(enr.IP(net.IP{4, 0, 2, 99}))
-	rec.SetSeq(a.Seq() + 1)
-	r.AddNodes(nil, []*enode.Node{enode.SignNull(&rec, a.ID())})
-	if _, ok := bucket.att[a.ID()]; ok {
-		t.Fatal("node a should have been dropped")
-	}
-
-	// /24-X now holds exactly 1 (c): exactly one more fits, a second is rejected.
-	f := nodeAtDistance(base, 200, net.IP{3, 0, 2, 3})
-	g := nodeAtDistance(base, 200, net.IP{3, 0, 2, 4})
-	r.AddNodes(nil, []*enode.Node{f, g})
-	if _, ok := bucket.att[f.ID()]; !ok {
-		t.Fatal("one more node should fit in /24-X (limit 2)")
-	}
-	if _, ok := bucket.att[g.ID()]; ok {
-		t.Fatal("second extra node exceeds /24 limit — c's slot was undercounted")
-	}
-}
-
-// TestRegistrationRecordUpdateSameSubnet checks that a node refreshing its ENR
-// to a different host in the same /24 is kept (not evicted), even at IP limit 1.
-func TestRegistrationRecordUpdateSameSubnet(t *testing.T) {
-	cfg := testConfig(t)
-	r := NewRegistration(topic1, cfg)
-	base := enode.ID(topic1)
-
-	a := nodeAtDistance(base, 200, net.IP{3, 0, 2, 1})
-	r.AddNodes(nil, []*enode.Node{a})
-	bi := r.bucketIndex(a.ID())
-	bucket := &r.buckets[bi]
-
-	var rec enr.Record
-	rec.Set(enr.IP(net.IP{3, 0, 2, 250})) // same /24, different host
-	rec.SetSeq(a.Seq() + 1)
-	r.AddNodes(nil, []*enode.Node{enode.SignNull(&rec, a.ID())})
-
-	att, ok := bucket.att[a.ID()]
-	if !ok {
-		t.Fatal("node moving within its own /24 should be kept")
-	}
-	if got := att.Node.IP(); !got.Equal(net.IP{3, 0, 2, 250}) {
-		t.Fatalf("record not updated: IP=%v", got)
+			for _, p := range c.probes {
+				pn := nodeAtDistance(base, 200, p.ip)
+				r.AddNodes(nil, []*enode.Node{pn})
+				if _, ok := bucket.att[pn.ID()]; ok != p.admit {
+					t.Fatalf("probe %v admitted=%v, want %v", p.ip, ok, p.admit)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fix to keep ip buckets limits up to date when enr is updated with new ip

Closes #79