### PR TITLE
p2p/discover/topicindex:  keep ad cache ordered by expiry

### DIFF
--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -189,9 +189,6 @@ func (tab *TopicTable) add(n *enode.Node, topic TopicID) *topicTableEntry {
 		tab.reg[topic] = list.New()
 	}
 	reg.topicElem = tab.reg[topic].PushFront(reg)
-	// Append to the back so tab.all stays ordered by expiry (soonest at the
-	// front). Expire and NextExpiryTime rely on this: with a uniform ad
-	// lifetime, insertion order is expiry order.
 	reg.allElem = tab.all.PushBack(reg)
 	tab.wt.addReg(reg)
 	return reg

--- a/p2p/discover/topicindex/topictable.go
+++ b/p2p/discover/topicindex/topictable.go
@@ -189,7 +189,10 @@ func (tab *TopicTable) add(n *enode.Node, topic TopicID) *topicTableEntry {
 		tab.reg[topic] = list.New()
 	}
 	reg.topicElem = tab.reg[topic].PushFront(reg)
-	reg.allElem = tab.all.PushFront(reg)
+	// Append to the back so tab.all stays ordered by expiry (soonest at the
+	// front). Expire and NextExpiryTime rely on this: with a uniform ad
+	// lifetime, insertion order is expiry order.
+	reg.allElem = tab.all.PushBack(reg)
 	tab.wt.addReg(reg)
 	return reg
 }

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -101,11 +101,11 @@ func TestTopicTableRandomNodes(t *testing.T) {
 	t.Run(fmt.Sprint(N+1), func(t *testing.T) { check(t, N+1, N) })
 }
 
-// TestTopicTableRollingExpiry checks that an expired ad is reclaimed even while
-// the table is full and newer ads are still live, so a fresh registrant can be
+// TestTopicTableEviction checks that an expired ad is reclaimed even while the
+// table is full and newer ads are still live, so a fresh registrant can be
 // admitted. Ads are held in expiry order, so Expire must be able to drop the
 // oldest without being blocked by a newer entry.
-func TestTopicTableRollingExpiry(t *testing.T) {
+func TestTopicTableEviction(t *testing.T) {
 	simclock := new(mclock.Simulated)
 	cfg := testConfig(t)
 	cfg.AdCacheSize = 3

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -101,10 +101,10 @@ func TestTopicTableRandomNodes(t *testing.T) {
 	t.Run(fmt.Sprint(N+1), func(t *testing.T) { check(t, N+1, N) })
 }
 
-// TestTopicTableEviction checks that an expired ad is reclaimed even while the
-// table is full and newer ads are still live, so a fresh registrant can be
-// admitted. Ads are held in expiry order, so Expire must be able to drop the
-// oldest without being blocked by a newer entry.
+// TestTopicTableEviction checks that ads are evicted when they expire: at the
+// right time (not before), driven by expiry rather than by the table filling up,
+// dropping only the expired ad while newer ones stay — and that a full table can
+// then admit a fresh registrant once an expired ad is reclaimed.
 func TestTopicTableEviction(t *testing.T) {
 	simclock := new(mclock.Simulated)
 	cfg := testConfig(t)
@@ -112,23 +112,48 @@ func TestTopicTableEviction(t *testing.T) {
 	cfg.Clock = simclock
 	tab := NewTopicTable(cfg)
 	L := tab.AdLifetime()
+	t0 := simclock.Now()
 
-	// Fill the table with staggered expiry times: A < B < C.
-	tab.Add(newNode(), topic1) // A: exp = L
+	// Two ads with staggered expiry. The table is not full, so any eviction here
+	// is driven by expiry time, not by capacity.
+	a, b := newNode(), newNode()
+	tab.Add(a, topic1) // A: exp = t0 + L
 	simclock.Run(time.Minute)
-	tab.Add(newNode(), topic1) // B: exp = L + 1m
-	simclock.Run(time.Minute)
-	tab.Add(newNode(), topic1) // C: exp = L + 2m  (table now full)
+	tab.Add(b, topic1) // B: exp = t0 + L + 1m
 
-	// Advance until only A has expired.
-	simclock.Run(L - 2*time.Minute + 30*time.Second) // now = L + 30s
-	tab.Expire()
-
-	if got := tab.all.Len(); got != 2 {
-		t.Fatalf("expired ad not reclaimed: Len=%d, want 2 (Expire blocked by a newer live ad)", got)
+	// The next expiry must be A's (the soonest), even with free space.
+	if got, want := tab.NextExpiryTime(), t0.Add(L); got != want {
+		t.Fatalf("NextExpiryTime = %v, want A's expiry %v", got, want)
 	}
+
+	// Just before A expires: nothing is evicted (not too early).
+	simclock.Run(L - time.Minute - time.Second) // now = t0 + L - 1s
+	tab.Expire()
+	if got := tab.all.Len(); got != 2 {
+		t.Fatalf("evicted before expiry: Len=%d, want 2", got)
+	}
+
+	// Just after A expires (B still live): only A is dropped.
+	simclock.Run(2 * time.Second) // now = t0 + L + 1s
+	tab.Expire()
+	if tab.isRegistered(a, topic1) {
+		t.Fatal("expired ad A was not evicted")
+	}
+	if !tab.isRegistered(b, topic1) {
+		t.Fatal("live ad B was wrongly evicted")
+	}
+
+	// Fill the table (B + two fresh ads), confirm it's full, then let B expire so
+	// exactly one slot frees and a new registrant can be admitted.
+	tab.Add(newNode(), topic1)
+	tab.Add(newNode(), topic1)
+	if tab.Add(newNode(), topic1) {
+		t.Fatal("table should be full")
+	}
+	simclock.Run(time.Minute) // now = t0 + L + 1m + 1s : B expired, the two fresh ads live
+	tab.Expire()
 	if !tab.Add(newNode(), topic1) {
-		t.Fatal("could not admit a new ad after an old one expired: table jammed")
+		t.Fatal("full table did not admit a new ad after eviction")
 	}
 }
 

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -101,10 +101,6 @@ func TestTopicTableRandomNodes(t *testing.T) {
 	t.Run(fmt.Sprint(N+1), func(t *testing.T) { check(t, N+1, N) })
 }
 
-// TestTopicTableEviction checks that ads are evicted when they expire: at the
-// right time (not before), driven by expiry rather than by the table filling up,
-// dropping only the expired ad while newer ones stay — and that a full table can
-// then admit a fresh registrant once an expired ad is reclaimed.
 func TestTopicTableEviction(t *testing.T) {
 	simclock := new(mclock.Simulated)
 	cfg := testConfig(t)

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -22,7 +22,9 @@ import (
 	mrand "math/rand"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/internal/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -97,6 +99,37 @@ func TestTopicTableRandomNodes(t *testing.T) {
 	t.Run(fmt.Sprint(N), func(t *testing.T) { check(t, N, N) })
 	t.Run(fmt.Sprint(N-1), func(t *testing.T) { check(t, N-1, N-1) })
 	t.Run(fmt.Sprint(N+1), func(t *testing.T) { check(t, N+1, N) })
+}
+
+// TestTopicTableRollingExpiry checks that an expired ad is reclaimed even while
+// the table is full and newer ads are still live, so a fresh registrant can be
+// admitted. Ads are held in expiry order, so Expire must be able to drop the
+// oldest without being blocked by a newer entry.
+func TestTopicTableRollingExpiry(t *testing.T) {
+	simclock := new(mclock.Simulated)
+	cfg := testConfig(t)
+	cfg.AdCacheSize = 3
+	cfg.Clock = simclock
+	tab := NewTopicTable(cfg)
+	L := tab.AdLifetime()
+
+	// Fill the table with staggered expiry times: A < B < C.
+	tab.Add(newNode(), topic1) // A: exp = L
+	simclock.Run(time.Minute)
+	tab.Add(newNode(), topic1) // B: exp = L + 1m
+	simclock.Run(time.Minute)
+	tab.Add(newNode(), topic1) // C: exp = L + 2m  (table now full)
+
+	// Advance until only A has expired.
+	simclock.Run(L - 2*time.Minute + 30*time.Second) // now = L + 30s
+	tab.Expire()
+
+	if got := tab.all.Len(); got != 2 {
+		t.Fatalf("expired ad not reclaimed: Len=%d, want 2 (Expire blocked by a newer live ad)", got)
+	}
+	if !tab.Add(newNode(), topic1) {
+		t.Fatal("could not admit a new ad after an old one expired: table jammed")
+	}
 }
 
 func testConfig(t *testing.T) Config {


### PR DESCRIPTION
Pushing new ads to front can make old ads are non evicted, since more recent ads will come first when iterating to check for expired ads, and the iteration stops when non expired ads are found. Fixed by pushing to back instead to keep them in order where expired will always come first. 

Closes #98