### PR TITLE
p2p/discover/v5wire: bound variable-length topic message fields at decode

### DIFF
--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -123,6 +123,10 @@ var (
 var (
 	// ErrInvalidReqID represents error when the ID is invalid.
 	ErrInvalidReqID = errors.New("request ID larger than 8 bytes")
+
+	// ErrOversizedField is returned when a topic message carries a
+	// variable-length field that exceeds its decode-time bound.
+	ErrOversizedField = errors.New("oversized topic message field")
 )
 
 // IsInvalidHeader reports whether 'err' is related to an invalid packet header. When it

--- a/p2p/discover/v5wire/msg.go
+++ b/p2p/discover/v5wire/msg.go
@@ -56,6 +56,25 @@ const (
 	WhoareyouPacket = byte(254) // the WHOAREYOU packet
 )
 
+// Decode-time bounds on the variable-length fields of the topic-discovery
+// messages. These are defense-in-depth: the transport MTU and the message
+// handlers bound these fields further, but the decoder should reject clearly
+// oversized inputs on its own.
+const (
+	// Worst-case decode bounds on the variable-length topic-message fields. They
+	// are deliberately loose upper limits — chosen so they can never reject a
+	// valid message — that reject only absurd inputs; the authoritative limits
+	// are enforced downstream (handler truncation, ticket Unpack, packet MTU).
+
+	// maxTopicBucketCount: one entry per log-distance; distance 0 is the node
+	// itself, so valid distances are 1..256.
+	maxTopicBucketCount = 256
+	// maxTopicNodeCount: the discv5 per-response NODES limit.
+	maxTopicNodeCount = 16
+	// maxTicketSizeBytes: the sealed ticket is a fixed 90 bytes (Unpack enforces it).
+	maxTicketSizeBytes = 90
+)
+
 // Protocol messages.
 type (
 	// Unknown represents any packet that can't be decrypted.
@@ -203,6 +222,24 @@ func DecodeMessage(ptype byte, body []byte) (Packet, error) {
 	}
 	if dec.RequestID() != nil && len(dec.RequestID()) > 8 {
 		return nil, ErrInvalidReqID
+	}
+	switch m := dec.(type) {
+	case *Regtopic:
+		if len(m.Buckets) > maxTopicBucketCount || len(m.Ticket) > maxTicketSizeBytes {
+			return nil, ErrOversizedField
+		}
+	case *Regconfirmation:
+		if len(m.Ticket) > maxTicketSizeBytes {
+			return nil, ErrOversizedField
+		}
+	case *TopicQuery:
+		if len(m.Buckets) > maxTopicBucketCount {
+			return nil, ErrOversizedField
+		}
+	case *TopicNodes:
+		if len(m.Nodes) > maxTopicNodeCount {
+			return nil, ErrOversizedField
+		}
 	}
 	return dec, nil
 }


### PR DESCRIPTION
Closes #100

Stacked on #93. Adds decode-time caps for the topic messages' variable-length fields (Buckets/Nodes/Ticket); makes `TestTopicMessageOversizedFields` (added in #93) pass. Code only — the test lives in #93.