### PR TITLE
ci: add GitHub Actions CI on hosted runners for topdisc

### DIFF
--- a/.github/workflows/ci-topdisc.yml
+++ b/.github/workflows/ci-topdisc.yml
@@ -1,9 +1,5 @@
 name: CI
 
-# Runs on GitHub-hosted runners. The upstream go.yml targets `master` and the
-# Ethereum Foundation's self-hosted runners, so it never fires for this fork.
-# Scoped to p2p/... (the active development area) for fast, green PR feedback;
-# broaden once stable.
 on:
   push:
     branches: [topdisc, master]

--- a/.github/workflows/ci-topdisc.yml
+++ b/.github/workflows/ci-topdisc.yml
@@ -29,7 +29,7 @@ jobs:
       - name: go vet
         run: go vet ./p2p/...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.10.1
           args: --timeout=10m ./p2p/...

--- a/.github/workflows/ci-topdisc.yml
+++ b/.github/workflows/ci-topdisc.yml
@@ -1,0 +1,52 @@
+name: CI
+
+# Runs on GitHub-hosted runners. The upstream go.yml targets `master` and the
+# Ethereum Foundation's self-hosted runners, so it never fires for this fork.
+# Scoped to p2p/... (the active development area) for fast, green PR feedback;
+# broaden once stable.
+on:
+  push:
+    branches: [topdisc, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: gofmt
+        run: |
+          out=$(gofmt -l p2p)
+          if [ -n "$out" ]; then echo "gofmt needed on:"; echo "$out"; exit 1; fi
+      - name: go vet
+        run: go vet ./p2p/...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.10.1
+          args: --timeout=10m ./p2p/...
+
+  test:
+    name: Test (Go ${{ matrix.go }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.24', '1.25']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test -timeout 20m ./p2p/...

--- a/p2p/discover/topicindex/iptree.go
+++ b/p2p/discover/topicindex/iptree.go
@@ -120,7 +120,6 @@ func (it *ipTree) remove(ip net.IP) {
 			*node = nil
 			return
 		}
-
 	}
 }
 

--- a/p2p/discover/topicindex/topictable_test.go
+++ b/p2p/discover/topicindex/topictable_test.go
@@ -113,14 +113,6 @@ func newNode() *enode.Node {
 	return enode.SignNull(&r, id)
 }
 
-func randomNodes(n int) []*enode.Node {
-	nodes := make([]*enode.Node, n)
-	for i := range nodes {
-		nodes[i] = newNode()
-	}
-	return nodes
-}
-
 func uniqueNodeIDs(nodes []*enode.Node) []enode.ID {
 	byID := make(map[enode.ID]struct{}, len(nodes))
 	for _, n := range nodes {

--- a/p2p/discover/v5_topic_test.go
+++ b/p2p/discover/v5_topic_test.go
@@ -260,13 +260,3 @@ func TestTopicDiscoveryFilterNodes(t *testing.T) {
 		t.Fatal("wrong node passed filter")
 	}
 }
-
-func countRegistrants(found map[enode.ID]bool, registrants map[enode.ID]bool) int {
-	count := 0
-	for id := range found {
-		if registrants[id] {
-			count++
-		}
-	}
-	return count
-}


### PR DESCRIPTION
Adds working CI for the fork. The inherited `go.yml` never runs here: it triggers only on `master` and uses the Ethereum Foundation's self-hosted runners.

This workflow runs on GitHub-hosted `ubuntu-latest`, triggers on `topdisc` + all PRs, and does:
- **Lint & vet** — gofmt check, `go vet ./p2p/...`, golangci-lint (pinned v2.10.1, repo `.golangci.yml`)
- **Test** — `go build ./...` + `go test ./p2p/...` on Go 1.24 and 1.25

Scoped to `p2p/...` (the active area) for fast, green feedback — validated locally: build/tests/gofmt/vet all pass (~1.5 min). Broaden coverage once stable.