### PR TITLE
p2p/discover/topicindex: gofmt iptree

### DIFF
--- a/p2p/discover/topicindex/iptree.go
+++ b/p2p/discover/topicindex/iptree.go
@@ -52,7 +52,7 @@ func (it *ipTree) insert(ip net.IP) float64 {
 	it.root.counter++
 	effectiveDepth := byte(0)
 	for depth := byte(0); depth < it.bits; depth++ {
-		//beyond this point the tree has no statistical power to 
+		//beyond this point the tree has no statistical power to
 		// flag a bucket as overloaded
 		balanced := rootCounter / math.Pow(2, float64(depth+1))
 		if balanced < 1 {
@@ -90,7 +90,7 @@ func (it *ipTree) score(ip net.IP) float64 {
 		if balanced < 1 {
 			break
 		}
-		
+
 		effectiveDepth++
 		// mimic the behaviour of insert() that creates new nodes when
 		// adding an address and keeps increasing effectiveDepth.

--- a/p2p/discover/topicindex/iptree_test.go
+++ b/p2p/discover/topicindex/iptree_test.go
@@ -22,7 +22,7 @@ var ipv4TestOps = []treeAddOp{
 	{"1.1.1.1", 1.0},
 	{"8.8.8.8", 1.0},
 }
- 
+
 var ipv6TestOps = []treeAddOp{
 	{"fe80::716b:dafc:774e:a826", 0.0},
 	{"fe80::716b:dafc:774e:a827", 0.0},


### PR DESCRIPTION
gofmt the iptree files touched by #84 (trailing whitespace + missing final newline). Formatting only, no behaviour change.